### PR TITLE
Add DropBox for LCP server

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ func dbFromURI(uri string) (string, string) {
 }
 
 func main() {
-	var host, port, dbURI, storagePath, certFile, privKeyFile string
+	var host, port, dbURI, storagePath, dropBox, certFile, privKeyFile string
 	var readonly bool = false
 	var err error
 
@@ -54,10 +54,17 @@ func main() {
 		}
 	}
 
-	storagePath, _ = config.Get("storage.filesystem.storage")
+	storagePath, _ = config.Get("storage.filesystem.directory")
 	if storagePath == "" {
 		if storagePath = os.Getenv("STORAGE"); storagePath == "" {
 			storagePath = "files"
+		}
+	}
+
+	dropBox, _ = config.Get("dropbox.filesystem.directory")
+	if dropBox == "" {
+		if dropBox = os.Getenv("DROPBOX"); dropBox == "" {
+			dropBox = "dropbox"
 		}
 	}
 
@@ -108,10 +115,12 @@ func main() {
 		panic(err)
 	}
 
+	os.Mkdir(dropBox, os.ModePerm) //ignore the error, the folder can already exist
+
 	_, file, _, _ := runtime.Caller(0)
 	here := filepath.Dir(file)
 	static := filepath.Join(here, "/static")
 
-	s := server.New(":"+port, static, readonly, &idx, &store, &lst, &cert)
+	s := server.New(":"+port, static, readonly, &idx, &store, dropBox, &lst, &cert)
 	s.ListenAndServe()
 }


### PR DESCRIPTION
For large epub file (about 100MB), using HTTP request to transfert the
file (with api/store/{name} POST request) is not really a good idea
(regarding to the client thread locking during transfert, etc...).
DropBox is a directory where the clear epub files can be uploaded (with
SSH or using NFS mount for example). Then, the API client use the
api/storefromdropbox/{name} POST request to store the epub from dropox
to storage directory. Finally LCP server remove file from DropBox
directory.
