### PR TITLE
Fix: s/licence.lcpl/license.lcpl

### DIFF
--- a/server/api/license.go
+++ b/server/api/license.go
@@ -81,7 +81,7 @@ func GrantLicense(w http.ResponseWriter, r *http.Request, s Server) {
 			return
 		}
 
-		ep.Add("META-INF/licence.lcpl", &buf)
+		ep.Add("META-INF/license.lcpl", &buf)
 		w.Header().Add("Content-Type", "application/epub+zip")
 		w.Header().Add("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, indexItem.Filename))
 		ep.Write(w)


### PR DESCRIPTION
According to the LCP Specification, we have to use license.lcpl instead
of licence.lcpl into the ePub file
