### PR TITLE
Improve license rights defaults values

### DIFF
--- a/license/license.go
+++ b/license/license.go
@@ -48,8 +48,8 @@ type UserInfo struct {
 }
 
 type UserRights struct {
-	Print    int32      `json:"print"`
-	Copy     int32      `json:"copy"`
+	Print    int32      `json:"print,omitempty"`
+	Copy     int32      `json:"copy,omitempty"`
 	TTS      bool       `json:"tts"`
 	Editable bool       `json:"edit"`
 	Start    *time.Time `json:"start,omitempty"`
@@ -57,8 +57,6 @@ type UserRights struct {
 }
 
 var DefaultRights = UserRights{
-	Print:    10,
-	Copy:     10,
 	TTS:      true,
 	Editable: false,
 }


### PR DESCRIPTION
As specified in LCP 1.0 Doc, the default rights values are :
- Unlimited for print
- Unlimited for copy
- true for text to speech
- perpetual license for start and end

For print and copy, replace 10 by "Nothing" to specify "Unlimited"
in license.lcpl file
