### PR TITLE
Fix: Have to bypass ugly golang behavior

### DIFF
--- a/license/license.go
+++ b/license/license.go
@@ -48,8 +48,8 @@ type UserInfo struct {
 }
 
 type UserRights struct {
-	Print    int32      `json:"print"`
-	Copy     int32      `json:"copy"`
+	Print    *int32     `json:"print,omitempty"`
+	Copy     *int32     `json:"copy,omitempty"`
 	TTS      bool       `json:"tts"`
 	Editable bool       `json:"edit"`
 	Start    *time.Time `json:"start,omitempty"`
@@ -57,8 +57,6 @@ type UserRights struct {
 }
 
 var DefaultRights = UserRights{
-	Print:    -1,
-	Copy:     -1,
 	TTS:      true,
 	Editable: false,
 }


### PR DESCRIPTION
Golang Json Marshaller consider int32 0 as nil !

The awaited behavior :

+-------------------------------------------------------------------+
| print or copy value | value in license | meaning                  |
+---------------------+------------------+--------------------------+
| 0                   | 0                | print or copy forbidden  |
| empty               | void             | Unlimited                |
| X or Y              | X or Y           | print or copy restricted |
+-------------------------------------------------------------------+

The bug was :
+----------------------------------------+
| print or copy value | value in license | 
+---------------------+------------------+
| 0                   | void             |
| empty               | void             |
| X or Y              | X or Y           |
+----------------------------------------+

Now :
+-------------------------------------------------------------------+
| print or copy value | value in license | meaning                  |
+---------------------+------------------+--------------------------+
| 0                   | 0                | print or copy forbidden  |
| -1                  | -1               | Unlimited                |
| X or Y              | X or Y           | print or copy restricted |
+-------------------------------------------------------------------+
