### PR TITLE
Fix: modify signature algorithm in license file

### DIFF
--- a/sign/sign.go
+++ b/sign/sign.go
@@ -37,7 +37,7 @@ func (s *rsaSigner) Sign(in interface{}) (sig Signature, err error) {
 	}
 
 	sig.Hash = res
-	sig.Algorithm = "http://www.w3.org/2000/09/xmldsig#rsa-sha256"
+	sig.Algorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
 	sig.Certificate = s.cert.Certificate[0]
 	return
 }


### PR DESCRIPTION
Regarding to LCP specification, we have to replace:
  "http://www.w3.org/2000/09/xmldsig#rsa-sha25"
by
  "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
as signature algorithm in license file
