### PR TITLE
Refactor the packaging workflow in an agnostic interface, add S3 as a new storage implementation

### DIFF
--- a/epub/epub.go
+++ b/epub/epub.go
@@ -1,6 +1,7 @@
 package epub
 
 import (
+	"archive/zip"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -22,8 +23,9 @@ func (ep Epub) Cover() (bool, *Resource) {
 	for _, p := range ep.Package {
 		for _, it := range p.Manifest.Items {
 			if strings.Contains(it.Properties, "cover-image") {
+				path := filepath.Join(p.BasePath, it.Href)
 				for _, r := range ep.Resource {
-					if r.Path == filepath.Join(p.BasePath, it.Href) {
+					if r.Path == path {
 						return true, r
 					}
 				}
@@ -35,18 +37,19 @@ func (ep Epub) Cover() (bool, *Resource) {
 }
 
 func (ep *Epub) Add(name string, body io.Reader, size uint64) error {
-	ep.Resource = append(ep.Resource, &Resource{Contents: body, Compressed: false, Path: name, OriginalSize: size})
+	ep.Resource = append(ep.Resource, &Resource{Contents: body, StorageMethod: zip.Deflate, Path: name, OriginalSize: size})
 
 	return nil
 }
 
 type Resource struct {
-	Contents     io.Reader
-	Compressed   bool
-	Path         string
-	ContentType  string
-	OriginalSize uint64
-	ContentsSize uint64
+	Path          string
+	ContentType   string
+	OriginalSize  uint64
+	ContentsSize  uint64
+	Compressed    bool
+	StorageMethod uint16
+	Contents      io.Reader
 }
 
 func (ep Epub) CanEncrypt(file string) bool {

--- a/epub/writer_test.go
+++ b/epub/writer_test.go
@@ -3,6 +3,7 @@ package epub
 import (
 	"archive/zip"
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -81,10 +82,14 @@ func TestWriteBasicEpub(t *testing.T) {
 	testContentsOfFileInZip(t, zr, zip.Store, "mimetype", "application/epub+zip")
 	testContentsOfFileInZip(t, zr, zip.Deflate, "META-INF/container.xml", containerSpec)
 	testContentsOfFileInZip(t, zr, zip.Deflate, "EPUB/package.opf", basicOpf)
-	testContentsOfFileInZip(t, zr, zip.Store, "EPUB/page.xhtml", basicPage)
+	testContentsOfFileInZip(t, zr, zip.Deflate, "EPUB/page.xhtml", basicPage)
 }
 
 func testContentsOfFileInZip(t *testing.T, zr *zip.Reader, m uint16, path, expected string) {
+	for _, f := range zr.File {
+		fmt.Println(f.Name)
+	}
+
 	if f, err := findFileInZip(zr, path); err != nil {
 		t.Fatalf("Could not find %s in file", path)
 	} else {

--- a/pack/pipeline.go
+++ b/pack/pipeline.go
@@ -1,0 +1,161 @@
+package pack
+
+import (
+	"archive/zip"
+	"io"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/readium/readium-lcp-server/epub"
+	"github.com/readium/readium-lcp-server/index"
+	"github.com/readium/readium-lcp-server/storage"
+	"github.com/satori/go.uuid"
+)
+
+type Source interface {
+	Feed(chan<- *Task)
+}
+
+type Task struct {
+	Name string
+	Body io.ReaderAt
+	Size int64
+	done chan Result
+}
+
+func NewTask(name string, body io.ReaderAt, size int64) *Task {
+	return &Task{Name: name, Body: body, Size: size, done: make(chan Result, 1)}
+}
+
+type Result struct {
+	Error   error
+	Id      string
+	Elapsed time.Duration
+}
+
+func (t *Task) Wait() Result {
+	r := <-t.done
+	return r
+}
+
+func (t *Task) Done(r Result) {
+	t.done <- r
+}
+
+type ManualSource struct {
+	ch chan<- *Task
+}
+
+func (s *ManualSource) Feed(ch chan<- *Task) {
+	s.ch = ch
+}
+
+func (s *ManualSource) Post(t *Task) Result {
+	s.ch <- t
+	return t.Wait()
+}
+
+type Packager struct {
+	Incoming chan *Task
+	done     chan struct{}
+	store    storage.Store
+	idx      index.Index
+}
+
+func (p Packager) work() {
+	for t := range p.Incoming {
+		r := Result{}
+		p.genKey(&r)
+		zr := p.readZip(&r, t.Body, t.Size)
+		epub := p.readEpub(&r, zr)
+		encrypted, key := p.encrypt(&r, epub)
+		p.addToStore(&r, encrypted)
+		p.addToIndex(&r, key, t.Name)
+
+		t.Done(r)
+	}
+}
+
+func (p Packager) genKey(r *Result) {
+	if r.Error != nil {
+		return
+	}
+
+	r.Id = uuid.NewV4().String()
+}
+
+func (p Packager) readZip(r *Result, in io.ReaderAt, size int64) *zip.Reader {
+	if r.Error != nil {
+		return nil
+	}
+
+	zr, err := zip.NewReader(in, size)
+	r.Error = err
+	return zr
+}
+
+func (p Packager) readEpub(r *Result, zr *zip.Reader) epub.Epub {
+	if r.Error != nil {
+		return epub.Epub{}
+	}
+
+	ep, err := epub.Read(zr)
+	r.Error = err
+
+	return ep
+}
+
+func (p Packager) encrypt(r *Result, ep epub.Epub) (*os.File, []byte) {
+	if r.Error != nil {
+		return nil, nil
+	}
+
+	file, err := ioutil.TempFile(os.TempDir(), "out-readium-lcp")
+
+	if err != nil {
+		r.Error = err
+		return nil, nil
+	}
+
+	_, key, err := Do(ep, file)
+	r.Error = err
+
+	file.Seek(0, 0)
+
+	return file, key
+}
+
+func (p Packager) addToStore(r *Result, f *os.File) {
+	if r.Error != nil {
+		return
+	}
+
+	_, r.Error = p.store.Add(r.Id, f)
+
+	f.Close()
+	os.Remove(f.Name())
+}
+
+func (p Packager) addToIndex(r *Result, key []byte, name string) {
+	if r.Error != nil {
+		return
+	}
+
+	r.Error = p.idx.Add(index.Package{r.Id, key, name})
+}
+
+func NewPackager(store storage.Store, idx index.Index, concurrency int) *Packager {
+	packager := Packager{
+		Incoming: make(chan *Task),
+		done:     make(chan struct{}),
+		store:    store,
+		idx:      idx,
+	}
+
+	for i := 0; i < concurrency; i++ {
+		go packager.work()
+	}
+
+	return &packager
+}

--- a/server/api/license.go
+++ b/server/api/license.go
@@ -58,7 +58,13 @@ func GrantLicense(w http.ResponseWriter, r *http.Request, s Server) {
 			return
 		}
 		var b bytes.Buffer
-		io.Copy(&b, item.Contents())
+		contents, err := item.Contents()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		io.Copy(&b, contents)
 		zr, err := zip.NewReader(bytes.NewReader(b.Bytes()), int64(b.Len()))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/storage/fs_test.go
+++ b/storage/fs_test.go
@@ -23,7 +23,7 @@ func TestFileSystemStorage(t *testing.T) {
 
 	store := NewFileSystem(dir, "http://localhost/assets")
 
-	item, err := store.Add("test", bytes.NewBufferString("test1234"))
+	item, err := store.Add("test", bytes.NewReader([]byte("test1234")))
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
@@ -38,24 +38,25 @@ func TestFileSystemStorage(t *testing.T) {
 	}
 
 	var buf [8]byte
-	if _, err = io.ReadFull(item.Contents(), buf[:]); err != nil {
-		t.Error(err)
-		t.FailNow()
+	contents, err := item.Contents()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = io.ReadFull(contents, buf[:]); err != nil {
+		t.Fatal(err)
 	} else {
 		if string(buf[:]) != "test1234" {
 			t.Error("expected buf to be test1234, got ", string(buf[:]))
 		}
 	}
 
-	it := store.List()
-
-	i := 0
-	for item, err = it(); err == nil; item, err = it() {
-		i++
+	results, err := store.List()
+	if err != nil {
+		t.Fatal(err)
 	}
 
-	if i != 1 {
-		t.Error("Expected 1 element, got ", i)
+	if len(results) != 1 {
+		t.Error("Expected 1 element, got ", len(results))
 	}
 
 }

--- a/storage/interface.go
+++ b/storage/interface.go
@@ -10,14 +10,12 @@ var NotFound = errors.New("Item could not be found")
 type Item interface {
 	Key() string
 	PublicUrl() string
-	Contents() io.Reader
+	Contents() (io.ReadCloser, error)
 }
 
-type Iterator func() (Item, error)
-
 type Store interface {
-	Add(key string, r io.Reader) (Item, error)
+	Add(key string, r io.ReadSeeker) (Item, error)
 	Get(key string) (Item, error)
 	Remove(key string) error
-	List() Iterator
+	List() ([]Item, error)
 }

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -1,0 +1,109 @@
+package storage
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+type s3store struct {
+	bucket string
+	client *s3.S3
+}
+
+type s3item struct {
+	bucket string
+	key    string
+	store  *s3store
+}
+
+func (i s3item) Key() string {
+	return i.key
+}
+
+func (i s3item) PublicUrl() string {
+	return fmt.Sprintf("http://%s/%s/%s", i.store.client.Endpoint, i.bucket, i.key)
+}
+
+func (i s3item) Contents() (io.ReadCloser, error) {
+	resp, err := i.store.client.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(i.store.bucket),
+		Key:    aws.String(i.key),
+	})
+
+	return resp.Body, err
+}
+
+func (s *s3store) Add(key string, r io.ReadSeeker) (Item, error) {
+	_, err := s.client.PutObject(&s3.PutObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+		Body:   r,
+	})
+
+	item := s3item{bucket: s.bucket, key: key, store: s}
+
+	return item, err
+}
+
+func (s *s3store) Get(key string) (Item, error) {
+	_, err := s.client.HeadObject(&s3.HeadObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	return s3item{bucket: s.bucket, key: key, store: s}, err
+}
+
+func (s *s3store) Remove(key string) error {
+	_, err := s.client.DeleteObject(&s3.DeleteObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+
+	return err
+}
+
+func (s *s3store) List() ([]Item, error) {
+	objects, err := s.client.ListObjects(&s3.ListObjectsInput{
+		Bucket: aws.String(s.bucket),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var items []Item
+
+	for _, o := range objects.Contents {
+		items = append(items, s3item{bucket: s.bucket, key: *o.Key, store: s})
+	}
+
+	return items, nil
+}
+
+type S3Config struct {
+	Bucket   string
+	Endpoint string
+	Region   string
+
+	Id     string
+	Secret string
+	Token  string
+
+	DisableSSL     bool
+	ForcePathStyle bool
+}
+
+func S3(config S3Config) (Store, error) {
+	client := s3.New(session.New(&aws.Config{
+		Credentials:      credentials.NewStaticCredentials(config.Id, config.Secret, config.Token),
+		DisableSSL:       aws.Bool(config.DisableSSL),
+		S3ForcePathStyle: aws.Bool(config.ForcePathStyle),
+		Region:           aws.String(config.Region),
+		Endpoint:         aws.String(config.Endpoint)}))
+	return &s3store{client: client, bucket: config.Bucket}, nil
+}

--- a/xmlenc/encryption.go
+++ b/xmlenc/encryption.go
@@ -11,6 +11,17 @@ type Manifest struct {
 	XMLName struct{} `xml:"urn:oasis:names:tc:opendocument:xmlns:container encryption"`
 }
 
+func (m Manifest) DataForFile(path string) (Data, bool) {
+	uri := URI(path)
+	for _, datum := range m.Data {
+		if datum.CipherData.CipherReference.URI == uri {
+			return datum, true
+		}
+	}
+
+	return Data{}, false
+}
+
 func (m Manifest) Write(w io.Writer) error {
 	w.Write([]byte(xml.Header))
 	enc := xml.NewEncoder(w)
@@ -94,11 +105,10 @@ type encryptedType struct {
 	Method     Method     `xml:"http://www.w3.org/2001/04/xmlenc# EncryptionMethod"`
 	KeyInfo    KeyInfo    `xml:"http://www.w3.org/2000/09/xmldsig# KeyInfo"`
 	CipherData CipherData `xml:"http://www.w3.org/2001/04/xmlenc# CipherData"`
-	//EncyrptionProperties interface{}
-	Id       string `xml:"Id,attr,omitempty"`
-	Type     URI    `xml:"Type,attr,omitempty"`
-	MimeType string `xml:"MimeType,omitempty"`
-	Encoding URI    `xml:"Encoding,omitempty"`
+	Id         string     `xml:"Id,attr,omitempty"`
+	Type       URI        `xml:"Type,attr,omitempty"`
+	MimeType   string     `xml:"MimeType,omitempty"`
+	Encoding   URI        `xml:"Encoding,omitempty"`
 }
 
 type ReferenceList struct {


### PR DESCRIPTION
The encryption (aka _packaging_) processing now is separated from the actual HTTP handler, so it can be reused in a different fashion, for example in a command line utility, or on a small daemon that scans a folder.

The basic setup is as is:

``` go
// Setup the file store and key index
fileStore =: store.NewFileSystem(...)
contentKeyIndex = index.NewSql(...)

// Give it a concurrency so more than one task can be processed at a time
concurrency := 4

// Setup the packager
packager := pack.NewPackager(fileStore, contentKeyIndex, concurrency)

// Define a source for the task. For the time being, this is a "manual" trigger, where a packaging request is sent when the Post method is called
var source pack.ManualSource

// Feed the source into the packager
source.Feed(packager.Incoming)

// Send a new task, waiting on the result
result := source.Post(pack.NewTask(filename, file, size))
fmt.Println("error:", result.err)
fmt.Println("content id:", result.Id)
```

The actual encrypting processing has also been revised to directly write a zip container, using an `epub.Writer` instance, instead of building a new `Epub` and paying the cost of keeping everything in memory multiple times. The encryption process now only uses as much memory as is required to encrypt a single resource in the container, so only a block size for AES-CBC.

I also added a S3-type storage implementation as an alternative to the file system.
