### PR TITLE
Create a new interface to manage the encryption algorithm, implement GCM

### DIFF
--- a/crypto/aes_cbc.go
+++ b/crypto/aes_cbc.go
@@ -1,0 +1,85 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"io"
+)
+
+type cbcEncrypter struct{}
+
+const (
+	aes256keyLength = 32 // 256 bits
+)
+
+func (e cbcEncrypter) Signature() string {
+	return "http://www.w3.org/2001/04/xmlenc#aes256-cbc"
+}
+
+func (e cbcEncrypter) GenerateKey() (ContentKey, error) {
+	slice, err := GenerateKey(aes256keyLength)
+	return ContentKey(slice), err
+}
+
+func (e cbcEncrypter) Encrypt(key ContentKey, r io.Reader, w io.Writer) error {
+	r = PaddedReader(r, aes.BlockSize)
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return err
+	}
+
+	// generate the IV
+	iv := make([]byte, aes.BlockSize)
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return err
+	}
+
+	// write the IV first
+	if _, err = w.Write(iv); err != nil {
+		return err
+	}
+
+	mode := cipher.NewCBCEncrypter(block, iv)
+	buffer := make([]byte, aes.BlockSize)
+	for _, err = io.ReadFull(r, buffer); err == nil; _, err = io.ReadFull(r, buffer) {
+		mode.CryptBlocks(buffer, buffer)
+		_, wErr := w.Write(buffer)
+		if wErr != nil {
+			return wErr
+		}
+	}
+
+	if err == nil || err == io.EOF {
+		return nil
+	}
+
+	return err
+}
+
+func (c cbcEncrypter) Decrypt(key ContentKey, r io.Reader, w io.Writer) error {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return err
+	}
+
+	var buffer bytes.Buffer
+	io.Copy(&buffer, r)
+
+	buf := buffer.Bytes()
+	iv := buf[:aes.BlockSize]
+
+	mode := cipher.NewCBCDecrypter(block, iv)
+	mode.CryptBlocks(buf[aes.BlockSize:], buf[aes.BlockSize:])
+
+	padding := buf[len(buf)-1]
+	w.Write(buf[aes.BlockSize : len(buf)-int(padding)])
+
+	return nil
+}
+
+func NewAESCBCEncrypter() Encrypter {
+	return cbcEncrypter(struct{}{})
+}

--- a/crypto/aes_cbc_test.go
+++ b/crypto/aes_cbc_test.go
@@ -12,7 +12,9 @@ func TestSimpleEncrypt(t *testing.T) {
 	var output bytes.Buffer
 	var key [32]byte //not a safe key to have
 
-	err := Encrypt(key[:], input, &output)
+	cbc := NewAESCBCEncrypter()
+
+	err := cbc.Encrypt(key[:], input, &output)
 
 	if err != nil {
 		t.Log(err)
@@ -31,7 +33,9 @@ func TestConsecutiveEncrypts(t *testing.T) {
 	var output bytes.Buffer
 	var key [32]byte //not a safe key to have
 
-	err := Encrypt(key[:], input, &output)
+	cbc := NewAESCBCEncrypter()
+
+	err := cbc.Encrypt(key[:], input, &output)
 
 	if err != nil {
 		t.Log(err)
@@ -41,7 +45,7 @@ func TestConsecutiveEncrypts(t *testing.T) {
 	input = bytes.NewBufferString("1234")
 	var output2 bytes.Buffer
 
-	err = Encrypt(key[:], input, &output2)
+	err = cbc.Encrypt(key[:], input, &output2)
 
 	if err != nil {
 		t.Log(err)
@@ -56,7 +60,10 @@ func TestConsecutiveEncrypts(t *testing.T) {
 func TestFailingReaderForEncryption(t *testing.T) {
 	var output bytes.Buffer
 	var key [32]byte //not a safe key to have
-	err := Encrypt(key[:], failingReader{}, &output)
+
+	cbc := NewAESCBCEncrypter()
+
+	err := cbc.Encrypt(key[:], failingReader{}, &output)
 
 	if err == nil {
 		t.Error("expected an error from the reader")
@@ -68,12 +75,14 @@ func TestDecrypt(t *testing.T) {
 	key := sha256.Sum256([]byte("password"))
 	var cipher bytes.Buffer
 
-	err := Encrypt(key[:], clear, &cipher)
+	cbc := &cbcEncrypter{}
+	err := cbc.Encrypt(key[:], clear, &cipher)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	var res bytes.Buffer
-	err = Decrypt(key[:], &cipher, &res)
+	err = cbc.Decrypt(key[:], &cipher, &res)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/crypto/aes_gcm.go
+++ b/crypto/aes_gcm.go
@@ -1,0 +1,51 @@
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/binary"
+	"io"
+	"io/ioutil"
+)
+
+type gcmEncrypter struct {
+	counter uint64
+}
+
+func (e gcmEncrypter) Signature() string {
+	return "http://www.w3.org/2009/xmlenc11#aes256-gcm"
+}
+
+func (e gcmEncrypter) GenerateKey() (ContentKey, error) {
+	slice, err := GenerateKey(aes256keyLength)
+	return ContentKey(slice), err
+}
+
+func (e *gcmEncrypter) Encrypt(key ContentKey, r io.Reader, w io.Writer) error {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return err
+	}
+
+	counter := e.counter
+	e.counter++
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	binary.BigEndian.PutUint64(nonce, counter)
+
+	data, err := ioutil.ReadAll(r)
+	out := gcm.Seal(nonce, nonce, data, nil)
+
+	_, err = w.Write(out)
+
+	return err
+}
+
+func NewAESGCMEncrypter() Encrypter {
+	return &gcmEncrypter{}
+}

--- a/crypto/aes_gcm_test.go
+++ b/crypto/aes_gcm_test.go
@@ -1,0 +1,44 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/hex"
+	"testing"
+)
+
+func TestEncryptGCM(t *testing.T) {
+	key, _ := hex.DecodeString("11754cd72aec309bf52f7687212e8957")
+
+	encrypter := NewAESGCMEncrypter()
+
+	data := []byte("The quick brown fox jumps over the lazy dog")
+
+	r := bytes.NewReader(data)
+	w := new(bytes.Buffer)
+
+	if err := encrypter.Encrypt(ContentKey(key), r, w); err != nil {
+		t.Fatal("Encryption failed", err)
+	}
+
+	block, _ := aes.NewCipher(key)
+	gcm, _ := cipher.NewGCM(block)
+
+	out := w.Bytes()
+	t.Logf("nonce size: %#v", gcm.NonceSize())
+	t.Logf("nonce: %#v", out[0:gcm.NonceSize()])
+	t.Logf("ciphertext: %#v", out[gcm.NonceSize():])
+	clear := make([]byte, 0)
+	clear, err := gcm.Open(clear, out[0:gcm.NonceSize()], out[gcm.NonceSize():], nil)
+
+	if err != nil {
+		t.Fatal("Decryption failed", err)
+	}
+
+	if diff := bytes.Compare(data, clear); diff != 0 {
+		t.Logf("Original: %#v", data)
+		t.Logf("After cycle: %#v", clear)
+		t.Errorf("Expected encryption-decryption to return original")
+	}
+}

--- a/crypto/encrypt.go
+++ b/crypto/encrypt.go
@@ -1,69 +1,18 @@
 package crypto
 
 import (
-	"bytes"
 	"crypto/aes"
-	"crypto/cipher"
-	"crypto/rand"
 	"io"
 )
 
-func Encrypt(key []byte, r io.Reader, w io.Writer) error {
-	r = PaddedReader(r, aes.BlockSize)
-
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return err
-	}
-
-	// generate the IV
-	iv := make([]byte, aes.BlockSize)
-	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
-		return err
-	}
-
-	// write the IV first
-	if _, err = w.Write(iv); err != nil {
-		return err
-	}
-
-	mode := cipher.NewCBCEncrypter(block, iv)
-	buffer := make([]byte, aes.BlockSize)
-	for _, err = io.ReadFull(r, buffer); err == nil; _, err = io.ReadFull(r, buffer) {
-		mode.CryptBlocks(buffer, buffer)
-		_, wErr := w.Write(buffer)
-		if wErr != nil {
-			return wErr
-		}
-	}
-
-	if err == nil || err == io.EOF {
-		return nil
-	}
-
-	return err
+type Encrypter interface {
+	Encrypt(key ContentKey, r io.Reader, w io.Writer) error
+	GenerateKey() (ContentKey, error)
+	Signature() string
 }
 
-func Decrypt(key []byte, r io.Reader, w io.Writer) error {
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return err
-	}
-
-	var buffer bytes.Buffer
-	io.Copy(&buffer, r)
-
-	buf := buffer.Bytes()
-	iv := buf[:aes.BlockSize]
-
-	mode := cipher.NewCBCDecrypter(block, iv)
-	mode.CryptBlocks(buf[aes.BlockSize:], buf[aes.BlockSize:])
-
-	padding := buf[len(buf)-1]
-	w.Write(buf[aes.BlockSize : len(buf)-int(padding)])
-
-	return nil
-
+type Decrypter interface {
+	Decrypt(key ContentKey, r io.Reader, w io.Writer) error
 }
 
 var (

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -4,12 +4,10 @@ import (
 	"crypto/rand"
 )
 
-const (
-	keyLength = 32 // 256 bits
-)
+type ContentKey []byte
 
-func GenerateKey() ([]byte, error) {
-	k := make([]byte, keyLength)
+func GenerateKey(size int) ([]byte, error) {
+	k := make([]byte, size)
 
 	_, err := rand.Read(k)
 	if err != nil {

--- a/crypto/key_test.go
+++ b/crypto/key_test.go
@@ -1,11 +1,9 @@
 package crypto
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestGenerateKey(t *testing.T) {
-	buf, err := GenerateKey()
+	buf, err := GenerateKey(aes256keyLength)
 
 	if err != nil {
 		t.Error(err)

--- a/lcpencrypt/lcpencrypt.go
+++ b/lcpencrypt/lcpencrypt.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/readium/readium-lcp-server/crypto"
 	"github.com/readium/readium-lcp-server/epub"
 	"github.com/readium/readium-lcp-server/pack"
 )
@@ -157,7 +158,8 @@ func main() {
 		return
 	}
 
-	_, encryptionKey, err := pack.Do(ep, output)
+	encrypter := crypto.NewAESCBCEncrypter()
+	_, encryptionKey, err := pack.Do(encrypter, ep, output)
 	output.Close()
 	if err != nil {
 		addedPublication.ErrorMessage = "Error packing"

--- a/license/store_test.go
+++ b/license/store_test.go
@@ -41,7 +41,7 @@ func TestStoreAdd(t *testing.T) {
 	Prepare(&l)
 	err = st.Add(l)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	l2, err := st.Get(l.Id)

--- a/server/api/store.go
+++ b/server/api/store.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/gorilla/mux"
+	"github.com/readium/readium-lcp-server/crypto"
 	"github.com/readium/readium-lcp-server/index"
 	"github.com/readium/readium-lcp-server/license"
 	"github.com/readium/readium-lcp-server/pack"
@@ -22,6 +23,7 @@ type Server interface {
 	Licenses() license.Store
 	Certificate() *tls.Certificate
 	Source() *pack.ManualSource
+	Encrypter() crypto.Encrypter
 }
 
 func writeRequestFileToTemp(r io.Reader) (int64, *os.File, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/gorilla/mux"
+	"github.com/readium/readium-lcp-server/crypto"
 	"github.com/readium/readium-lcp-server/index"
 	"github.com/readium/readium-lcp-server/license"
 	"github.com/readium/readium-lcp-server/pack"
@@ -45,6 +46,10 @@ func (s *Server) Certificate() *tls.Certificate {
 
 func (s *Server) Source() *pack.ManualSource {
 	return &s.source
+}
+
+func (s *Server) Encrypter() crypto.Encrypter {
+	return crypto.NewAESCBCEncrypter()
 }
 
 func New(bindAddr string, tplPath string, readonly bool, idx *index.Index, st *storage.Store, lst *license.Store, cert *tls.Certificate, packager *pack.Packager) *Server {


### PR DESCRIPTION
This commit was based off of the last good commit, so it is in conflict with master.

It introduces a new interface, crypto.Encrypter, with 2 implementations. One for AES256-CBC and the other for AES256-GCM.

The encrypter has 3 responsibilities:
- Generating a new private key of the proper size
- Encrypting a content from a Reader into a Writer, using the provided key.
- Outputting the proper algorithm signature for the License and XMLENC

(Additionally, there is the inverse operation for testing purposes)

Right now, CBC is the one instantiated through the code for backwards compatibility, but it should become a config based on the given LCP Profile.
