### PR TITLE
Fix /licenses API method

### DIFF
--- a/license_statuses/license_statuses.go
+++ b/license_statuses/license_statuses.go
@@ -159,7 +159,7 @@ func Open(db *sql.DB) (l LicenseStatuses, err error) {
 		return
 	}
 
-	list, err := db.Prepare(`SELECT * FROM license_status WHERE device_count > ?
+	list, err := db.Prepare(`SELECT * FROM license_status WHERE device_count >= ?
 		ORDER BY id DESC LIMIT ? OFFSET ?`)
 
 	getbylicenseid, err := db.Prepare("SELECT * FROM license_status where license_ref = ?")


### PR DESCRIPTION
This method was returning license status with a number of devices greater than the one provides in the request
