### PR TITLE
github.com/go-yaml/yaml import has to change

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/go-yaml/yaml"
+	"gopkg.in/yaml.v2"
 )
 
 type Configuration struct {


### PR DESCRIPTION
github.com/go-yaml/yaml is not longer availabel, use
gopkg.in/yaml.v2 now.