### PR TITLE
AES256 CBC W3C padding scheme (instead of PKCS#7)

### DIFF
--- a/crypto/pad.go
+++ b/crypto/pad.go
@@ -27,6 +27,8 @@ package crypto
 
 import (
 	"io"
+	"math/rand"
+	"time"
 )
 
 type paddedReader struct {
@@ -73,9 +75,12 @@ func (r *paddedReader) Read(buf []byte) (int, error) {
 
 func (r *paddedReader) pad(buf []byte) (i int, err error) {
 	capacity := cap(buf)
+	src := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i = 0; capacity > 0 && r.left > 0; i++ {
 		if capacity == 1 && r.left == 1 {
 			buf[i] = r.count
+		} else {
+			buf[i] = byte(src.Intn(254) + 1)
 		}
 		capacity--
 		r.left--


### PR DESCRIPTION
In reaction to:
https://github.com/readium/readium-lcp-server/issues/18#issuecomment-272347995

It write pad size in the last of pad, and another pad block is not initialized.