### PR TITLE
Add hex_value param to partial license

### DIFF
--- a/lcpserver/api/license.go
+++ b/lcpserver/api/license.go
@@ -8,6 +8,7 @@ package apilcp
 import (
 	"archive/zip"
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,27 +31,37 @@ import (
 
 // ErrMandatoryInfoMissing sets an error message returned to the caller
 var ErrMandatoryInfoMissing = errors.New("Mandatory info missing in the input body")
+var ErrBadHexValue = errors.New("Erroneous Hex Value can't be decoded")
 
-// get license, check mandatory information in the input body
+// checkGetLicenseInput: if we generate or get a license, check mandatory information in the input body
+// and compute request parameters.
 //
 func checkGetLicenseInput(l *license.License) error {
+	// the user hint is mandatory
 	if l.Encryption.UserKey.Hint == "" {
 		log.Println("User hint is missing")
 		return ErrMandatoryInfoMissing
 	}
-	if l.Encryption.UserKey.Value == nil {
+	if l.Encryption.UserKey.HexValue != "" {
+		// compute a byte array from a string
+		value, err := hex.DecodeString(l.Encryption.UserKey.HexValue)
+		if err != nil {
+			return ErrBadHexValue
+		}
+		l.Encryption.UserKey.Value = value
+	} else if l.Encryption.UserKey.Value == nil {
 		log.Println("User hashed passphrase is missing")
 		return ErrMandatoryInfoMissing
 	}
 	if l.Encryption.UserKey.Algorithm == "" {
 		log.Println("User passphrase hash algorithm is missing, set default value")
-		// the only valid value in LCP basic and 10 profiles is sha256
+		// the only valid value in LCP basic and 1.0 profiles is sha256
 		l.Encryption.UserKey.Algorithm = "http://www.w3.org/2001/04/xmlenc#sha256"
 	}
 	return nil
 }
 
-// generate license, check mandatory information in the input body
+// checkGenerateLicenseInput: if we generate a license, check mandatory information in the input body
 //
 func checkGenerateLicenseInput(l *license.License) error {
 	if l.Provider == "" {
@@ -61,7 +72,7 @@ func checkGenerateLicenseInput(l *license.License) error {
 		log.Println("User identification is missing")
 		return ErrMandatoryInfoMissing
 	}
-	// check userkey hint, value and algorithm
+	// check user hint, passphrase hash and hash algorithm
 	err := checkGetLicenseInput(l)
 	return err
 }

--- a/license/license.go
+++ b/license/license.go
@@ -35,9 +35,10 @@ type ContentKey struct {
 
 type UserKey struct {
 	Key
-	Hint  string `json:"text_hint,omitempty"`
-	Check []byte `json:"key_check,omitempty"`
-	Value []byte `json:"value,omitempty"` //Used for the license request
+	Hint     string `json:"text_hint,omitempty"`
+	Check    []byte `json:"key_check,omitempty"`
+	Value    []byte `json:"value,omitempty"`     //Used for license generation
+	HexValue string `json:"hex_value,omitempty"` //Used for license generation
 }
 
 type Encryption struct {
@@ -198,6 +199,7 @@ func EncryptLicenseFields(l *License, c index.Content) error {
 
 	// empty the passphrase hash to avoid sending it back to the user
 	l.Encryption.UserKey.Value = nil
+	l.Encryption.UserKey.HexValue = ""
 
 	// encrypt the content key with the user key
 	encrypterContentKey := crypto.NewAESEncrypter_CONTENT_KEY()


### PR DESCRIPTION
Evolution related to issue #180. 

Add `hex_value` to the json partial license, mapped to `HexValue` in the in-memory model, as a string.
Add a mapping from `HexValue` (string) to `Value` (byte array) if not empty, when processing a license generation request. Treat the case where the HexValue cannot be mapped (hex.DecodeString fails). 
Empty `HexValue' from the completed license before it is returned to the caller. 