### PR TITLE
Skip directory entries when reading EPUB files

### DIFF
--- a/epub/reader.go
+++ b/epub/reader.go
@@ -141,6 +141,12 @@ func Read(r *zip.Reader) (Epub, error) {
 	}
 
 	for _, file := range r.File {
+
+		// EPUBs do not require us to keep directory entries and we cannot process them
+		if file.FileInfo().IsDir() {
+			continue
+		}
+
 		if file.Name != EncryptionFile &&
 			file.Name != "mimetype" {
 			rc, err := file.Open()

--- a/epub/reader_test.go
+++ b/epub/reader_test.go
@@ -21,7 +21,7 @@
 // LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 // ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package epub
 
@@ -50,7 +50,7 @@ func TestEpubLoading(t *testing.T) {
 	}
 
 	if len(ep.Package) != 1 {
-		t.Error("Expected 1 opf, got %d", len(ep.Package))
+		t.Errorf("Expected 1 opf, got %d", len(ep.Package))
 	}
 
 	expectedCleartext := []string{ContainerFile, "OPS/package.opf", "OPS/images/9780316000000.jpg", "OPS/toc.xhtml"}


### PR DESCRIPTION
Fixes #185. We no longer treat directory entries as resources, as there is nothing good an EPUB can do with them.

I also fixed a deprecated way to signal errors in tests that would make them fail,  you now have to be explicit about calling `Errorf` when you have placeholders