### PR TITLE
Develop

### DIFF
--- a/frontend/webpublication/webpublication.go
+++ b/frontend/webpublication/webpublication.go
@@ -210,12 +210,6 @@ func EncryptEPUB(inputPath string, pub Publication, pubManager PublicationManage
 		return err
 	}
 
-	// remove the temporary file in the "encrypted repository"
-	err = os.Remove(outputPath)
-	if err != nil {
-		return err
-	}
-
 	// store the new publication in the db
 	// the publication uuid is the lcp db content id.
 	pub.UUID = contentUUID

--- a/lcpencrypt/lcpencrypt.go
+++ b/lcpencrypt/lcpencrypt.go
@@ -46,6 +46,7 @@ import (
 	"github.com/readium/readium-lcp-server/epub"
 	"github.com/readium/readium-lcp-server/lcpserver/api"
 	"github.com/readium/readium-lcp-server/pack"
+	uuid "github.com/satori/go.uuid"
 )
 
 // notification of newly added content (Publication)
@@ -180,8 +181,11 @@ func main() {
 		exitWithError(addedPublication, err, 70)
 	}
 	if *contentid == "" { // contentID not set -> generate a new one
-		sha := sha256.Sum256(buf)
-		*contentid = fmt.Sprintf("%x", sha)
+		uid, err_u := uuid.NewV4()
+		if err_u != nil {
+			exitWithError(addedPublication, err, 65)
+		}
+		*contentid = uid.String()
 	}
 	var basefilename string
 	addedPublication.ContentId = *contentid


### PR DESCRIPTION
Correction of an error in the frontend: there was a duplicate tentative suppression of the tmp file in the frontend server part, now that the lcp server deletes it.

Plus a minor modification: the contentid generated by lcpencrypt is now a uuid (was a sha). Same as the one generated from the frontend. 