### PR TITLE
Test/keepclear

### DIFF
--- a/epub/epub.go
+++ b/epub/epub.go
@@ -28,6 +28,7 @@ package epub
 import (
 	"archive/zip"
 	"io"
+	"log"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -104,5 +105,11 @@ type Resource struct {
 
 func (ep Epub) CanEncrypt(file string) bool {
 	i := sort.SearchStrings(ep.cleartextResources, file)
+	response := (i >= len(ep.cleartextResources) || ep.cleartextResources[i] != file)
+	if response {
+		log.Println("I can encrypt " + file)
+	} else {
+		log.Println("I will NOT encrypt " + file)
+	}
 	return i >= len(ep.cleartextResources) || ep.cleartextResources[i] != file
 }

--- a/epub/epub.go
+++ b/epub/epub.go
@@ -1,34 +1,13 @@
-// Copyright (c) 2016 Readium Foundation
-//
-// Redistribution and use in source and binary forms, with or without modification,
-// are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation and/or
-//    other materials provided with the distribution.
-// 3. Neither the name of the organization nor the names of its contributors may be
-//    used to endorse or promote products derived from this software without specific
-//    prior written permission
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright 2019 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
 
 package epub
 
 import (
 	"archive/zip"
 	"io"
-	"log"
 	"sort"
 	"strings"
 
@@ -104,9 +83,6 @@ type Resource struct {
 
 func (ep Epub) CanEncrypt(file string) bool {
 	i := sort.SearchStrings(ep.cleartextResources, file)
-	response := (i >= len(ep.cleartextResources) || ep.cleartextResources[i] != file)
-	if !response {
-		log.Println("I will NOT encrypt " + file)
-	}
+
 	return i >= len(ep.cleartextResources) || ep.cleartextResources[i] != file
 }

--- a/epub/epub.go
+++ b/epub/epub.go
@@ -29,7 +29,6 @@ import (
 	"archive/zip"
 	"io"
 	"log"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -74,7 +73,7 @@ func (ep Epub) Cover() (bool, *Resource) {
 			if strings.Contains(it.Properties, "cover-image") ||
 				it.Id == coverImageID {
 
-				path := filepath.Join(p.BasePath, it.Href)
+				path := p.BasePath + "/" + it.Href
 				for _, r := range ep.Resource {
 					if r.Path == path {
 						return true, r
@@ -106,9 +105,7 @@ type Resource struct {
 func (ep Epub) CanEncrypt(file string) bool {
 	i := sort.SearchStrings(ep.cleartextResources, file)
 	response := (i >= len(ep.cleartextResources) || ep.cleartextResources[i] != file)
-	if response {
-		log.Println("I can encrypt " + file)
-	} else {
+	if !response {
 		log.Println("I will NOT encrypt " + file)
 	}
 	return i >= len(ep.cleartextResources) || ep.cleartextResources[i] != file

--- a/epub/reader.go
+++ b/epub/reader.go
@@ -29,6 +29,7 @@ import (
 	"archive/zip"
 	"encoding/xml"
 	"io"
+	"log"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -70,6 +71,7 @@ func findRootFiles(r io.Reader) ([]rootFile, error) {
 	return roots, nil
 }
 
+/*
 func (ep *Epub) addCleartextResources(names []string) {
 	if ep.cleartextResources == nil {
 		ep.cleartextResources = []string{}
@@ -79,6 +81,7 @@ func (ep *Epub) addCleartextResources(names []string) {
 		ep.cleartextResources = append(ep.cleartextResources, name)
 	}
 }
+*/
 
 func (ep *Epub) addCleartextResource(name string) {
 	if ep.cleartextResources == nil {
@@ -184,8 +187,6 @@ func Read(r *zip.Reader) (Epub, error) {
 	ep.Encryption = encryption
 	sort.Strings(ep.cleartextResources)
 
-	//log.Print(fmt.Sprintf("%v", ep.cleartextResources))
-
 	return ep, nil
 }
 
@@ -207,6 +208,10 @@ func addCleartextResources(ep *Epub, p opf.Package) {
 			item.MediaType == ContentType_NCX {
 
 			ep.addCleartextResource(filepath.Join(p.BasePath, item.Href))
+
+			// debug
+			log.Println("basepath: " + p.BasePath + " href: " + item.Href)
+			log.Println("added to clear: " + filepath.Join(p.BasePath, item.Href))
 		}
 	}
 }

--- a/epub/reader.go
+++ b/epub/reader.go
@@ -207,11 +207,10 @@ func addCleartextResources(ep *Epub, p opf.Package) {
 			strings.Contains(item.Properties, "nav") ||
 			item.MediaType == ContentType_NCX {
 
-			ep.addCleartextResource(filepath.Join(p.BasePath, item.Href))
+			ep.addCleartextResource(p.BasePath + "/" + item.Href)
 
 			// debug
-			log.Println("basepath: " + p.BasePath + " href: " + item.Href)
-			log.Println("added to clear: " + filepath.Join(p.BasePath, item.Href))
+			log.Println("added to clear: " + p.BasePath + "/" + item.Href)
 		}
 	}
 }

--- a/epub/reader.go
+++ b/epub/reader.go
@@ -1,27 +1,7 @@
-// Copyright (c) 2016 Readium Foundation
-//
-// Redistribution and use in source and binary forms, with or without modification,
-// are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation and/or
-//    other materials provided with the distribution.
-// 3. Neither the name of the organization nor the names of its contributors may be
-//    used to endorse or promote products derived from this software without specific
-//    prior written permission
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// Copyright 2019 European Digital Reading Lab. All rights reserved.
+// Licensed to the Readium Foundation under one or more contributor license agreements.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
 
 package epub
 
@@ -29,7 +9,6 @@ import (
 	"archive/zip"
 	"encoding/xml"
 	"io"
-	"log"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -70,18 +49,6 @@ func findRootFiles(r io.Reader) ([]rootFile, error) {
 
 	return roots, nil
 }
-
-/*
-func (ep *Epub) addCleartextResources(names []string) {
-	if ep.cleartextResources == nil {
-		ep.cleartextResources = []string{}
-	}
-
-	for _, name := range names {
-		ep.cleartextResources = append(ep.cleartextResources, name)
-	}
-}
-*/
 
 func (ep *Epub) addCleartextResource(name string) {
 	if ep.cleartextResources == nil {
@@ -206,11 +173,9 @@ func addCleartextResources(ep *Epub, p opf.Package) {
 			item.Id == coverImageID ||
 			strings.Contains(item.Properties, "nav") ||
 			item.MediaType == ContentType_NCX {
-
+			// re-construct a path, avoids insertion of backslash as separator on Windows.
 			ep.addCleartextResource(p.BasePath + "/" + item.Href)
 
-			// debug
-			log.Println("added to clear: " + p.BasePath + "/" + item.Href)
 		}
 	}
 }


### PR DESCRIPTION
Correction of an issue on Windows systems, where the cover and ToC were encrypted because of a path manipulation. 
Removal of an unused function also named addCleartextResources().
Update of the copyright header.