### PR TITLE
Send NULLs instead of zero-ed dates when adding license

### DIFF
--- a/license_statuses/license_statuses.go
+++ b/license_statuses/license_statuses.go
@@ -87,11 +87,12 @@ func (i dbLicenseStatuses) Add(ls LicenseStatus) error {
 	statusDB, err := status.SetStatus(ls.Status)
 
 	if err == nil {
-		var end time.Time
+		var end *time.Time
+		end = nil
 		if ls.PotentialRights != nil && ls.PotentialRights.End != nil && !(*ls.PotentialRights.End).IsZero() {
-			end = *ls.PotentialRights.End
+			end = ls.PotentialRights.End
 		}
-		_, err = add.Exec(statusDB, ls.Updated.License, ls.Updated.Status, ls.DeviceCount, &end, ls.LicenseRef, ls.CurrentEndLicense)
+		_, err = add.Exec(statusDB, ls.Updated.License, ls.Updated.Status, ls.DeviceCount, end, ls.LicenseRef, ls.CurrentEndLicense)
 	}
 
 	return err


### PR DESCRIPTION
MySQL does not allow for '0000-00-00' for a null date.  The date must be a NULL value.