### PR TITLE
fix: Make AWS STS token optional

### DIFF
--- a/storage/s3.go
+++ b/storage/s3.go
@@ -135,7 +135,7 @@ func S3(config S3Config) (Store, error) {
 	// Credentials defaults to a chain of credential providers to search for credentials in environment
 	// variables, shared credential file, and EC2 Instance Roles.
 	// Therefore, we only explicitly define static credentials if these are present in config
-	if config.ID != "" && config.Secret != "" && config.Token != "" {
+	if config.ID != "" && config.Secret != "" {
 		awsConfig.Credentials = credentials.NewStaticCredentials(config.ID, config.Secret, config.Token)
 	}
 


### PR DESCRIPTION
This PR makes AWS STS token optional while creating a new S3 client.
According to [the documentation](https://docs.aws.amazon.com/sdk-for-go/api/aws/credentials/#NewStaticCredentials):
```
Token is only required for temporary security credentials retrieved via STS, otherwise an empty string can be passed for this parameter.
```