### PR TITLE
Add license_id parameter to lcpserver's hint link

### DIFF
--- a/license/license.go
+++ b/license/license.go
@@ -206,6 +206,12 @@ func SetLicenseLinks(l *License, c index.Content) error {
 			l.Links[i].Href = strings.Replace(l.Links[i].Href, "{license_id}", l.ID, 1)
 			l.Links[i].Type = api.ContentType_LSD_JSON
 		}
+
+		// hint link
+		if l.Links[i].Rel == "hint" {
+			l.Links[i].Href = strings.Replace(l.Links[i].Href, "{license_id}", l.ID, 1)
+			l.Links[i].Type = api.ContentType_TEXT_HTML
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR adds `license_id` parameter to lcpserver's 'hint' link.
This is required for NYPL's SimplyE to be able to use a single LCP/LSD server with multiple libraries. You can find more information in [SIMPLY-3121](https://jira.nypl.org/browse/SIMPLY-3121).
In the case of SimplyE `hint` look will look like the following:
```yaml
license:
  links:
    # ...
    hint: http://{{ getv "/cm/hostname" }}/LCP/lcp/licenses/{license_id}/hint
```