### PR TITLE
handle pre generated UUID as query parameter

### DIFF
--- a/frontend/api/publication.go
+++ b/frontend/api/publication.go
@@ -180,6 +180,9 @@ func UploadPublication(w http.ResponseWriter, r *http.Request, s IServer) {
 
 	// get the title of the publication from the 'title' URL query param
 	pub.Title = r.URL.Query()["title"][0]
+	if len(r.URL.Query()["uuid"]) > 0 {
+		pub.UUID = r.URL.Query()["uuid"][0]
+	}
 
 	// get the file handle
 	file, header, err := r.FormFile("file")

--- a/frontend/webpublication/webpublication.go
+++ b/frontend/webpublication/webpublication.go
@@ -148,6 +148,9 @@ func encryptPublication(inputPath string, pub Publication, pubManager Publicatio
 		return err
 	}
 	contentUUID := uid.String()
+	if len(pub.UUID) > 0 {
+		contentUUID = pub.UUID
+	}
 
 	// set the encryption profile from the config file
 	var lcpProfile license.EncryptionProfile


### PR DESCRIPTION
if UUID exists as query parameter, it will be used, otherwise fallback to default uuid generation 