### PR TITLE
Fix RWPM duration to float (not int)

### DIFF
--- a/pack/rwppackage.go
+++ b/pack/rwppackage.go
@@ -84,6 +84,9 @@ func (reader *RWPPReader) NewWriter(writer io.Writer) (PackageWriter, error) {
 	// FIXME: this doesn't seem to be the best location for such zip to zip copy
 	for _, manifestLink := range reader.manifest.Links {
 		sourceFile := files[manifestLink.Href]
+		if sourceFile == nil {
+			continue
+		}
 		fw, err := zipWriter.Create(sourceFile.Name)
 		if err != nil {
 			return nil, err

--- a/pack/w3cpackage.go
+++ b/pack/w3cpackage.go
@@ -295,10 +295,10 @@ func newUUID() (string, error) {
 	return fmt.Sprintf("%x-%x-%x-%x-%x", uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:]), nil
 }
 
-// isoDurationToSc transforms an ISO duration to a number of seconds
-func isoDurationToSc(iso string) (seconds int, err error) {
+// isoDurationToSc transforms an ISO duration to a number of seconds, as a float
+func isoDurationToSc(iso string) (seconds float32, err error) {
 	period, err := period.Parse(iso)
-	seconds = period.Hours()*3600 + period.Minutes()*60 + period.Seconds()
+	seconds = float32(period.Hours()*3600 + period.Minutes()*60 + period.Seconds())
 	return
 }
 

--- a/rwpm/metadata.go
+++ b/rwpm/metadata.go
@@ -38,11 +38,10 @@ type Metadata struct {
 	Penciler    Contributors `json:"penciler,omitempty"`
 	Translator  Contributors `json:"translator,omitempty"`
 	// other descriptive metadata
-	Subject Subjects `json:"subject,omitempty"`
-	// FIXME: Duration is a float in the spec
-	Duration      int  `json:"duration,omitempty"`
-	NumberOfPages int  `json:"numberOfPages,omitempty"`
-	Abridged      bool `json:"abridged,omitempty"`
+	Subject       Subjects `json:"subject,omitempty"`
+	Duration      float32  `json:"duration,omitempty"`
+	NumberOfPages int      `json:"numberOfPages,omitempty"`
+	Abridged      bool     `json:"abridged,omitempty"`
 	// collections & series
 	BelongsTo *BelongsTo `json:"belongsTo,omitempty"`
 

--- a/rwpm/publication.go
+++ b/rwpm/publication.go
@@ -31,15 +31,14 @@ type Publication struct {
 
 // Link object used in collections and links
 type Link struct {
-	Href      string      `json:"href"`
-	Templated bool        `json:"templated,omitempty"`
-	Type      string      `json:"type,omitempty"`
-	Title     string      `json:"title,omitempty"`
-	Rel       MultiString `json:"rel,omitempty"`
-	Height    int         `json:"height,omitempty"`
-	Width     int         `json:"width,omitempty"`
-	// FIXME: Duration is a float in the spec
-	Duration   int         `json:"duration,omitempty"`
+	Href       string      `json:"href"`
+	Templated  bool        `json:"templated,omitempty"`
+	Type       string      `json:"type,omitempty"`
+	Title      string      `json:"title,omitempty"`
+	Rel        MultiString `json:"rel,omitempty"`
+	Height     int         `json:"height,omitempty"`
+	Width      int         `json:"width,omitempty"`
+	Duration   float32     `json:"duration,omitempty"`
 	Bitrate    int         `json:"bitrate,omitempty"`
 	Properties *Properties `json:"properties,omitempty"`
 	Alternate  []Link      `json:"alternate,omitempty"`


### PR DESCRIPTION
Also solves a bug, import of an RWP file with a link which is not a resource in the zip.