### PR TITLE
Fix pdf encryption, add rpf processing

### DIFF
--- a/frontend/manage/app/publication/publication-form.component.html
+++ b/frontend/manage/app/publication/publication-form.component.html
@@ -26,7 +26,7 @@
                       class="drop-zone">
           <div *ngIf="droppedItem&&!notAPublication">{{droppedItem.file.name}}</div>
           <div *ngIf="!droppedItem&&!notAPublication">Drop a publication here</div>
-          <div *ngIf="droppedItem&&notAPublication">The file must have an .epub, .pdf, .lpf, .audiobook or .divina extension.</div>
+          <div *ngIf="droppedItem&&notAPublication">The file must have an .epub, .pdf, .lpf, .rpf, .audiobook or .divina extension.</div>
       </div>
     </div>
     <div *ngIf="form.value['type'] != 'UPLOAD'">

--- a/frontend/manage/app/publication/publication-form.component.html
+++ b/frontend/manage/app/publication/publication-form.component.html
@@ -17,7 +17,7 @@
       </label>
     </div>
     <br/>
-    <label for="publication-filename">EPUB, PDF, LPF or RWPP file</label>
+    <label for="publication-filename">EPUB, PDF, LPF or Readium Package file</label>
     <div *ngIf="form.value['type'] == 'UPLOAD'">
       <div ng2FileDrop
                       [ngClass]="{'nv-file-over': hasBaseDropZoneOver, 'nv-bad-file':notAPublication}"

--- a/frontend/manage/app/publication/publication-form.component.ts
+++ b/frontend/manage/app/publication/publication-form.component.ts
@@ -64,7 +64,7 @@ export class PublicationFormComponent implements OnInit {
         this.split = fileItem.file.name.split('.');
         let extension = this.split[this.split.length-1];
         if (extension === "epub" || extension === "pdf" || extension === "lpf" || 
-            extension === "audiobook" || extension === "divina")
+            extension === "rpf" || extension === "audiobook" || extension === "divina")
         {
             this.notAPublication = false;
         }

--- a/frontend/webpublication/webpublication.go
+++ b/frontend/webpublication/webpublication.go
@@ -209,6 +209,11 @@ func encryptPublication(inputPath string, pub Publication, pubManager Publicatio
 		contentType = "application/divina+lcp"
 		encryptedPub, err = encrypt.EncryptPackage(lcpProfile, inputPath, outputPath)
 
+		// process RPF PDF files
+	case ".rpf":
+		contentType = "application/pdf+lcp"
+		encryptedPub, err = encrypt.EncryptPackage(lcpProfile, inputPath, outputPath)
+
 		// unknown file
 	default:
 		return errors.New("Could not match the file extension: " + inputPath)

--- a/frontend/webpublication/webpublication.go
+++ b/frontend/webpublication/webpublication.go
@@ -140,7 +140,7 @@ func (pubManager PublicationManager) CheckByTitle(title string) (int64, error) {
 	return -1, ErrNotFound
 }
 
-// encryptPublication encrypts an EPUB, PDF, LPF or RWPP file and provides the resulting file to the LCP server
+// encryptPublication encrypts an EPUB, PDF, LPF or RPF file and provides the resulting file to the LCP server
 func encryptPublication(inputPath string, pub Publication, pubManager PublicationManager) error {
 
 	// generate a new uuid; this will be the content id in the lcp server
@@ -179,7 +179,7 @@ func encryptPublication(inputPath string, pub Publication, pubManager Publicatio
 	case ".pdf":
 		contentType = "application/pdf+lcp"
 		clearWebPubPath := outputPath + ".webpub"
-		err = pack.BuildRWPPFromPDF(pub.Title, inputPath, clearWebPubPath)
+		err = pack.BuildRPFFromPDF(pub.Title, inputPath, clearWebPubPath)
 		if err != nil {
 			log.Printf("Error building webpub package: %s", err)
 			return err
@@ -192,19 +192,19 @@ func encryptPublication(inputPath string, pub Publication, pubManager Publicatio
 		// FIXME: short term solution; should be extended to other profiles
 		contentType = "application/audiobook+lcp"
 		clearWebPubPath := outputPath + ".webpub"
-		err = pack.BuildRWPPFromLPF(inputPath, clearWebPubPath)
+		err = pack.BuildRPFFromLPF(inputPath, clearWebPubPath)
 		if err != nil {
 			return err
 		}
 		defer os.Remove(clearWebPubPath)
 		encryptedPub, err = encrypt.EncryptPackage(lcpProfile, clearWebPubPath, outputPath)
 
-		// process RWPP Audiobook files
+		// process RPF Audiobook files
 	case ".audiobook":
 		contentType = "application/audiobook+lcp"
 		encryptedPub, err = encrypt.EncryptPackage(lcpProfile, inputPath, outputPath)
 
-		// process RWPP Divina files
+		// process RPF Divina files
 	case ".divina":
 		contentType = "application/divina+lcp"
 		encryptedPub, err = encrypt.EncryptPackage(lcpProfile, inputPath, outputPath)

--- a/lcpencrypt/encrypt/encrypt.go
+++ b/lcpencrypt/encrypt/encrypt.go
@@ -35,7 +35,7 @@ func encryptionError(message string) (EncryptionArtifact, error) {
 	return EncryptionArtifact{}, errors.New(message)
 }
 
-// EncryptPackage generates an encrypted output RWPP out of the input RWPP
+// EncryptPackage generates an encrypted output RPF out of the input RPF
 // It is called from the test frontend server
 func EncryptPackage(profile license.EncryptionProfile, inputPath string, outputPath string) (EncryptionArtifact, error) {
 
@@ -43,7 +43,7 @@ func EncryptPackage(profile license.EncryptionProfile, inputPath string, outputP
 	encrypter := crypto.NewAESEncrypter_PUBLICATION_RESOURCES()
 
 	// create a reader on the un-encrypted readium package
-	reader, err := pack.OpenRWPP(inputPath)
+	reader, err := pack.OpenRPF(inputPath)
 	if err != nil {
 		return encryptionError(err.Error())
 	}

--- a/lcpencrypt/lcpencrypt.go
+++ b/lcpencrypt/lcpencrypt.go
@@ -134,12 +134,12 @@ func outputExtension(sourceExt string) string {
 	return targetExt
 }
 
-// buildEncryptedRWPP builds an encrypted Readium package out of an un-encrypted one
+// buildEncryptedRPF builds an encrypted Readium package out of an un-encrypted one
 // FIXME: it cannot be used for EPUB as long as Do() and Process() are not merged
-func buildEncryptedRWPP(pub *apilcp.LcpPublication, inputPath string, encrypter crypto.Encrypter, lcpProfile license.EncryptionProfile) error {
+func buildEncryptedRPF(pub *apilcp.LcpPublication, inputPath string, encrypter crypto.Encrypter, lcpProfile license.EncryptionProfile) error {
 
 	// create a reader on the un-encrypted readium package
-	reader, err := pack.OpenRWPP(inputPath)
+	reader, err := pack.OpenRPF(inputPath)
 	if err != nil {
 		pub.ErrorMessage = "Error opening package " + inputPath
 		return err
@@ -243,7 +243,7 @@ func processPDF(pub *apilcp.LcpPublication, inputPath string, encrypter crypto.E
 
 	// generate a temp Readium Package (rwpp) which embeds the PDF file; its title is the PDF file name
 	tmpPackagePath := pub.Output + ".tmp"
-	err := pack.BuildRWPPFromPDF(filepath.Base(inputPath), inputPath, tmpPackagePath)
+	err := pack.BuildRPFFromPDF(filepath.Base(inputPath), inputPath, tmpPackagePath)
 	if err != nil {
 		pub.ErrorMessage = "Error building Web Publication package from PDF"
 		return err
@@ -251,7 +251,7 @@ func processPDF(pub *apilcp.LcpPublication, inputPath string, encrypter crypto.E
 	defer os.Remove(tmpPackagePath)
 
 	// build an encrypted package
-	err = buildEncryptedRWPP(pub, tmpPackagePath, encrypter, lcpProfile)
+	err = buildEncryptedRPF(pub, tmpPackagePath, encrypter, lcpProfile)
 	return err
 }
 
@@ -264,22 +264,22 @@ func processLPF(pub *apilcp.LcpPublication, inputPath string, encrypter crypto.E
 
 	// generate a tmp Readium Package (rwpp) out of W3C Package (lpf)
 	tmpPackagePath := pub.Output + ".webpub"
-	err := pack.BuildRWPPFromLPF(inputPath, tmpPackagePath)
+	err := pack.BuildRPFFromLPF(inputPath, tmpPackagePath)
 	// will remove the tmp file even if an error is returned
 	defer os.Remove(tmpPackagePath)
 	// process error
 	if err != nil {
-		pub.ErrorMessage = "Error building RWPP from LPF"
+		pub.ErrorMessage = "Error building RPF from LPF"
 		return err
 	}
 
 	// build an encrypted package
-	err = buildEncryptedRWPP(pub, tmpPackagePath, encrypter, lcpProfile)
+	err = buildEncryptedRPF(pub, tmpPackagePath, encrypter, lcpProfile)
 	return err
 }
 
-// processRWPP encrypts the source Readium Package
-func processRWPP(pub *apilcp.LcpPublication, inputPath string, encrypter crypto.Encrypter, lcpProfile license.EncryptionProfile, outputExt string) error {
+// processRPF encrypts the source Readium Package
+func processRPF(pub *apilcp.LcpPublication, inputPath string, encrypter crypto.Encrypter, lcpProfile license.EncryptionProfile, outputExt string) error {
 
 	// select a mime-type
 	switch outputExt {
@@ -290,7 +290,7 @@ func processRWPP(pub *apilcp.LcpPublication, inputPath string, encrypter crypto.
 	}
 
 	// build an encrypted package
-	err := buildEncryptedRWPP(pub, inputPath, encrypter, lcpProfile)
+	err := buildEncryptedRPF(pub, inputPath, encrypter, lcpProfile)
 	return err
 }
 
@@ -372,7 +372,7 @@ func main() {
 			exitWithError(pub, err, 32)
 		}
 	} else if inputExt == ".audiobook" {
-		err := processRWPP(&pub, *inputPath, encrypter, lcpProfile, outputExt)
+		err := processRPF(&pub, *inputPath, encrypter, lcpProfile, outputExt)
 		if err != nil {
 			exitWithError(pub, err, 33)
 		}

--- a/lcpencrypt/lcpencrypt.go
+++ b/lcpencrypt/lcpencrypt.go
@@ -122,6 +122,10 @@ func outputExtension(sourceExt string) string {
 		targetExt = ".epub"
 	case ".pdf":
 		targetExt = ".lcpdf"
+	case ".rpf":
+		// short term solution. We'll need to inspect the manifest and check conformsTo,
+		// to be certain this package contains a pdf
+		targetExt = ".lcpdf"
 	case ".audiobook":
 		targetExt = ".lcpau"
 	case ".divina":
@@ -258,7 +262,7 @@ func processPDF(pub *apilcp.LcpPublication, inputPath string, encrypter crypto.E
 // processLPF transforms a W3C LPF file into a Readium Package and encrypts its resources
 func processLPF(pub *apilcp.LcpPublication, inputPath string, encrypter crypto.Encrypter, lcpProfile license.EncryptionProfile, outputExt string) error {
 
-	// When other kinds of LPF files will be created, a switch on outputExt will be used
+	// When other kinds of LPF files are created, a switch on outputExt will be used
 	// to select the proper mime-type
 	pub.ContentType = "application/audiobook+lcp"
 
@@ -287,6 +291,8 @@ func processRPF(pub *apilcp.LcpPublication, inputPath string, encrypter crypto.E
 		pub.ContentType = "application/audiobook+lcp"
 	case ".lcpdi":
 		pub.ContentType = "application/divina+lcp"
+	case ".lcpdf":
+		pub.ContentType = "application/pdf+lcp"
 	}
 
 	// build an encrypted package
@@ -356,22 +362,23 @@ func main() {
 	encrypter := crypto.NewAESEncrypter_PUBLICATION_RESOURCES()
 
 	// select the encryption process
-	if inputExt == ".epub" {
+	switch inputExt {
+	case ".epub":
 		err := processEPUB(&pub, *inputPath, encrypter)
 		if err != nil {
 			exitWithError(pub, err, 30)
 		}
-	} else if inputExt == ".pdf" {
+	case ".pdf":
 		err := processPDF(&pub, *inputPath, encrypter, lcpProfile)
 		if err != nil {
 			exitWithError(pub, err, 31)
 		}
-	} else if inputExt == ".lpf" {
+	case ".lpf":
 		err := processLPF(&pub, *inputPath, encrypter, lcpProfile, outputExt)
 		if err != nil {
 			exitWithError(pub, err, 32)
 		}
-	} else if inputExt == ".audiobook" {
+	case ".audiobook", ".divina", ".rpf":
 		err := processRPF(&pub, *inputPath, encrypter, lcpProfile, outputExt)
 		if err != nil {
 			exitWithError(pub, err, 33)

--- a/lcpencrypt/lcpencrypt.go
+++ b/lcpencrypt/lcpencrypt.go
@@ -164,6 +164,13 @@ func buildEncryptedRWPP(pub *apilcp.LcpPublication, inputPath string, encrypter 
 		return err
 	}
 	pub.ContentKey = encryptionKey
+
+	err = writer.Close()
+	if err != nil {
+		pub.ErrorMessage = "Unable to close the writer"
+		return err
+	}
+
 	// calculate the output file size and checksum
 	stats, err := outputFile.Stat()
 	if err == nil && (stats.Size() > 0) {

--- a/pack/rwppackage.go
+++ b/pack/rwppackage.go
@@ -212,8 +212,9 @@ func (writer *RPFWriter) MarkAsEncrypted(path string, originalSize int64, profil
 				writer.manifest.ReadingOrder[i].Properties = new(rwpm.Properties)
 			}
 			writer.manifest.ReadingOrder[i].Properties.Encrypted = &rwpm.Encrypted{
-				Scheme:    "http://readium.org/2014/01/lcp",
-				Profile:   profile.String(),
+				Scheme: "http://readium.org/2014/01/lcp",
+				// profile data is not useful and even misleading: the same encryption algorithm applies to basic and 1.0 profiles.
+				//Profile:   profile.String(),
 				Algorithm: algorithm,
 			}
 

--- a/pack/rwppackage_test.go
+++ b/pack/rwppackage_test.go
@@ -111,7 +111,8 @@ func TestRWPM(t *testing.T) {
 	manifest.Metadata.Identifier = "id1"
 	manifest.Metadata.Title.Set("fr", "title")
 	manifest.Metadata.Description = "description"
-	manifest.Metadata.Published = rwpm.Date(time.Date(2020, 03, 05, 10, 00, 00, 0, time.UTC))
+	published := rwpm.Date(time.Date(2020, 03, 05, 10, 00, 00, 0, time.UTC))
+	manifest.Metadata.Published = &published
 	manifest.Metadata.Duration = 120
 	manifest.Metadata.Author.AddName("Laurent")
 	manifest.Metadata.Language.Add("fr")

--- a/pack/rwppackage_test.go
+++ b/pack/rwppackage_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/readium/readium-lcp-server/rwpm"
 )
 
-func TestOpenRWPPackage(t *testing.T) {
-	if _, err := OpenRWPP("path-does-not-exist.lcpdf"); err == nil {
+func TestOpenRPFackage(t *testing.T) {
+	if _, err := OpenRPF("path-does-not-exist.lcpdf"); err == nil {
 		t.Errorf("Expected to receive an error on missing file, got %s", err)
 	}
 
-	reader, err := OpenRWPP("./samples/basic.lcpdf")
+	reader, err := OpenRPF("./samples/basic.lcpdf")
 	if err != nil {
 		t.Fatalf("Expected to be able to open basic.lcpdf, got %s", err)
 	}
@@ -35,8 +35,8 @@ func TestOpenRWPPackage(t *testing.T) {
 	}
 }
 
-func TestWriteRWPPackage(t *testing.T) {
-	reader, err := OpenRWPP("./samples/basic.lcpdf")
+func TestWriteRPFackage(t *testing.T) {
+	reader, err := OpenRPF("./samples/basic.lcpdf")
 	if err != nil {
 		t.Fatalf("Expected to be able to open basic.lcpdf, got %s", err)
 	}
@@ -72,7 +72,7 @@ func TestWriteRWPPackage(t *testing.T) {
 		t.Fatalf("Could not reopen written archive, %s", err)
 	}
 
-	reader, err = NewRWPPReader(zr)
+	reader, err = NewRPFReader(zr)
 	if err != nil {
 		t.Fatalf("Could not read archive, %s", err)
 	}

--- a/pack/w3cpackage.go
+++ b/pack/w3cpackage.go
@@ -191,8 +191,8 @@ func generateRWPManifest(w3cman rwpm.W3CPublication) (manifest rwpm.Publication)
 	return
 }
 
-// BuildRWPPFromLPF builds a Readium package (rwpp) from a W3C LPF file (lpfPath)
-func BuildRWPPFromLPF(lpfPath string, rwppPath string) error {
+// BuildRPFFromLPF builds a Readium package (rwpp) from a W3C LPF file (lpfPath)
+func BuildRPFFromLPF(lpfPath string, rwppPath string) error {
 
 	// open the lpf file
 	lpfFile, err := zip.OpenReader(lpfPath)

--- a/pack/w3cpackage.go
+++ b/pack/w3cpackage.go
@@ -161,7 +161,11 @@ func generateRWPManifest(w3cman rwpm.W3CPublication) (manifest rwpm.Publication)
 	manifest.Metadata.Language = w3cman.InLanguage
 	// W3C manifest: published and modified are date-or-datetime,
 	// Readium manifest: published is a date; modified is a datetime
-	manifest.Metadata.Published = rwpm.Date(time.Time(*w3cman.DatePublished))
+	// The use of pointer helps dealing with nil values
+	if w3cman.DatePublished != nil {
+		published := rwpm.Date(time.Time(*w3cman.DatePublished))
+		manifest.Metadata.Published = &published
+	}
 	if w3cman.DateModified != nil {
 		modified := time.Time(*w3cman.DateModified)
 		manifest.Metadata.Modified = &modified

--- a/pack/w3cpackage_test.go
+++ b/pack/w3cpackage_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/readium/readium-lcp-server/rwpm"
 )
@@ -57,6 +58,13 @@ func TestMapW3CPublication(t *testing.T) {
 	}
 	if meta.Language[0] != "fr" || meta.Language[1] != "en" {
 		t.Fatalf("W3C InLanguage badly mapped")
+	}
+	if *meta.Published != rwpm.Date(time.Date(2020, 03, 23, 12, 50, 20, 0, time.UTC)) {
+		t.Fatalf("W3C DatePublished badly mapped")
+	}
+	mod := time.Date(2020, 03, 23, 16, 58, 27, 372000000, time.UTC)
+	if *meta.Modified != mod {
+		t.Fatalf("W3C DateModified badly mapped")
 	}
 	if meta.Duration != 150 {
 		t.Fatalf("W3C Duration badly mapped")

--- a/rwpm/metadata.go
+++ b/rwpm/metadata.go
@@ -22,7 +22,7 @@ type Metadata struct {
 	ReadingProgression string        `json:"readingProgression,omitempty"`
 	//
 	Modified  *time.Time `json:"modified,omitempty"`
-	Published Date       `json:"published,omitempty"`
+	Published *Date      `json:"published,omitempty"`
 	// contributors
 	Publisher   Contributors `json:"publisher,omitempty"`
 	Artist      Contributors `json:"artist,omitempty"`
@@ -71,12 +71,6 @@ func (d *DateOrDatetime) UnmarshalJSON(b []byte) error {
 
 // MarshalJSON marshalls DateOrDatetime
 func (d DateOrDatetime) MarshalJSON() ([]byte, error) {
-
-	//if time.Time(d).IsZero() {
-	//println("Zero dateordatetime")
-	//return nil, nil
-	//}
-
 	return json.Marshal(time.Time(d))
 }
 


### PR DESCRIPTION
- Fix a regression on the encryption of PDF file which appeared in v1.4.1, described in issue #255
- Fix the creation of a fake ("0001/01/01") date published in the generated manifest when a PDF file is encrypted.
- Handle the processing of RPF (Readium Packaging Format) files, especially when they contain PDF fields (with metadata and cover); as described in issue #247. 