### PR TITLE
Fetch a fresh license via the Status Doc Server

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,7 @@ type Configuration struct {
 	FrontendServer FrontendServerInfo `yaml:"frontend"`
 	LsdNotifyAuth  Auth               `yaml:"lsd_notify_auth"`
 	LcpUpdateAuth  Auth               `yaml:"lcp_update_auth"`
+	CMSAccessAuth  Auth               `yaml:"cms_access_auth"`
 	LicenseStatus  LicenseStatus      `yaml:"license_status"`
 	Localization   Localization       `yaml:"localization"`
 	ComplianceMode bool               `yaml:"compliance_mode"`
@@ -66,6 +67,7 @@ type ServerInfo struct {
 type LsdServerInfo struct {
 	ServerInfo     `yaml:",inline"`
 	LicenseLinkUrl string `yaml:"license_link_url,omitempty"`
+	UserDataUrl    string `yaml:"user_data_url,omitempty"`
 	LogDirectory   string `yaml:"log_directory"`
 }
 
@@ -113,8 +115,8 @@ type LicenseStatus struct {
 	Renew        bool   `yaml:"renew"`
 	Register     bool   `yaml:"register"`
 	Return       bool   `yaml:"return"`
-	RentingDays  int    `yaml:"renting_days" "default 0"`
-	RenewDays    int    `yaml:"renew_days" "default 0"`
+	RentingDays  int    `yaml:"renting_days"`
+	RenewDays    int    `yaml:"renew_days"`
 	RenewPageUrl string `yaml:"renew_page_url,omitempty"`
 }
 

--- a/frontend/webpurchase/webpurchase.go
+++ b/frontend/webpurchase/webpurchase.go
@@ -72,17 +72,17 @@ const (
 //Purchase struct defines a user in json and database
 //PurchaseType: BUY or LOAN
 type Purchase struct {
-	ID              int64                      `json:"id, omitempty"`
+	ID              int64                      `json:"id,omitempty"`
 	UUID            string                     `json:"uuid"`
 	Publication     webpublication.Publication `json:"publication"`
 	User            webuser.User               `json:"user"`
 	LicenseUUID     *string                    `json:"licenseUuid,omitempty"`
 	Type            string                     `json:"type"`
-	TransactionDate time.Time                  `json:"transactionDate, omitempty"`
-	StartDate       *time.Time                 `json:"startDate, omitempty"`
-	EndDate         *time.Time                 `json:"endDate, omitempty"`
+	TransactionDate time.Time                  `json:"transactionDate,omitempty"`
+	StartDate       *time.Time                 `json:"startDate,omitempty"`
+	EndDate         *time.Time                 `json:"endDate,omitempty"`
 	Status          string                     `json:"status"`
-	MaxEndDate      *time.Time                 `json:"maxEndDate, omitempty"`
+	MaxEndDate      *time.Time                 `json:"maxEndDate,omitempty"`
 }
 
 type PurchaseManager struct {
@@ -338,7 +338,6 @@ func (pManager PurchaseManager) GetPartialLicense(purchase Purchase) (license.Li
 	if err != nil {
 		return license.License{}, err
 	}
-	// FIXME: why this Close()?
 	defer resp.Body.Close()
 
 	// the call must return 206 (partial content) because there is no input partial license

--- a/lcpserver/server/server.go
+++ b/lcpserver/server/server.go
@@ -80,7 +80,7 @@ func New(bindAddr string, readonly bool, idx *index.Index, st *storage.Store, ls
 			Handler:        sr.N,
 			Addr:           bindAddr,
 			WriteTimeout:   240 * time.Second,
-			ReadTimeout:    5 * time.Second,
+			ReadTimeout:    15 * time.Second,
 			MaxHeaderBytes: 1 << 20,
 		},
 		readonly: readonly,

--- a/lsdserver/api/freshlicense.go
+++ b/lsdserver/api/freshlicense.go
@@ -1,0 +1,202 @@
+// Copyright 2021 Readium Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+
+package apilsd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+
+	"github.com/readium/readium-lcp-server/api"
+	"github.com/readium/readium-lcp-server/config"
+	"github.com/readium/readium-lcp-server/license"
+	"github.com/readium/readium-lcp-server/problem"
+)
+
+// UserData represents the payload requested to the CMS.
+// This is a simplified version of a partial license, easy to generate for any CMS developer.
+// PassphraseHash is the result of the hash calculation, as an hex-encoded string
+type UserData struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	Email          string `json:"email"`
+	PassphraseHash string `json:"passphrasehash"`
+	Hint           string `json:"hint"`
+}
+
+const Sha256_URL string = "http://www.w3.org/2001/04/xmlenc#sha256"
+
+// GetFreshLicense gets a fresh license from the License Server
+// after requesting user data (for this license) from the CMS.
+func GetFreshLicense(w http.ResponseWriter, r *http.Request, s Server) {
+
+	// get the licenseID parameter
+	vars := mux.Vars(r)
+	licenseID := vars["key"]
+
+	// check if the license is known from the Status Document Server
+	statusDoc, err := s.LicenseStatuses().GetByLicenseID(licenseID)
+	if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusNotFound)
+	}
+
+	// get a fresh license from the License Server (as []byte)
+	freshLicense, err := getLicense(licenseID)
+	if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusInternalServerError)
+		return
+	}
+
+	// return the fresh license to the caller
+	w.Header().Set("Content-Type", api.ContentType_LCP_JSON)
+	w.Header().Set("Content-Disposition", "attachment; filename=\"license.lcpl\"")
+
+	_, err = w.Write(freshLicense)
+	if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusInternalServerError)
+		return
+	}
+
+	log.Println("Get license / id " + licenseID + " / status " + statusDoc.Status)
+}
+
+// GetLicense gets a fresh license from the License Server
+func getLicense(licenseID string) (lic []byte, err error) {
+
+	// get user data from the CMS
+	var userData UserData
+	userData, err = getUserData(licenseID)
+	if err != nil {
+		return
+	}
+
+	// init the partial license to be sent to the License Server
+	var plic license.License
+	plic, err = initPartialLicense(licenseID, userData)
+	if err != nil {
+		return
+	}
+
+	// fetch the license from the License Server
+	lic, err = fetchLicense(plic)
+	if err != nil {
+		return
+	}
+	return
+}
+
+// getUserData gets user data from the CMS, as a partial license
+func getUserData(licenseID string) (userData UserData, err error) {
+
+	// get the url of the CMS
+	userURL := strings.Replace(config.Config.LsdServer.UserDataUrl, "{license_id}", licenseID, -1)
+	if userURL == "" {
+		err = errors.New("Get User Data from License ID: UserDataUrl missing from the server configuration")
+		return
+	}
+
+	// fetch user data
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", userURL, nil)
+	if err != nil {
+		return
+	}
+	auth := config.Config.CMSAccessAuth
+	if auth.Username != "" {
+		req.SetBasicAuth(auth.Username, auth.Password)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	dec := json.NewDecoder(resp.Body)
+	if resp.StatusCode != 200 {
+		var errStatus problem.Problem
+		err = dec.Decode(&errStatus)
+		if err != nil {
+			return
+		}
+		err = errors.New("Get User Data from License ID: " + errStatus.Title + " - " + errStatus.Detail)
+		return
+	} else {
+		// decode user data
+		err = dec.Decode(&userData)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// initPartialLicense inits the partial license to be sent to the License Server
+func initPartialLicense(licenseID string, userData UserData) (plic license.License, err error) {
+	plic.ID = licenseID
+	plic.User.ID = userData.ID
+	plic.User.Name = userData.Name
+	plic.User.Email = userData.Email
+	// we decide that name and email will be encrypted
+	encryptedAttrs := []string{"name", "email"}
+	plic.User.Encrypted = encryptedAttrs
+
+	plic.Encryption.UserKey.Algorithm = Sha256_URL
+	plic.Encryption.UserKey.Hint = userData.Hint
+	plic.Encryption.UserKey.HexValue = userData.PassphraseHash
+	return
+}
+
+// fetchLicense fetches a license from the License Server
+func fetchLicense(plic license.License) (lic []byte, err error) {
+	// json encode the partial license
+	jplic, err := json.Marshal(plic)
+	if err != nil {
+		return
+	}
+
+	// send the partial license to the License Server and get back a fresh license
+	licenseUrl := config.Config.LcpServer.PublicBaseUrl + "/licenses/" + plic.ID
+	client := &http.Client{}
+	req, err := http.NewRequest("POST", licenseUrl, bytes.NewReader(jplic))
+	if err != nil {
+		return
+	}
+	auth := config.Config.LcpUpdateAuth
+	if auth.Username != "" {
+		req.SetBasicAuth(auth.Username, auth.Password)
+	}
+	req.Header.Add("Content-Type", api.ContentType_LCP_JSON)
+	resp, err := client.Do(req)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		dec := json.NewDecoder(resp.Body)
+		var errStatus problem.Problem
+		err = dec.Decode(&errStatus)
+		if err != nil {
+			return
+		}
+		err = errors.New("Fetch License: " + errStatus.Title + " - " + errStatus.Detail)
+		return
+	} else {
+		// return the json body as []byte
+		lic, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}

--- a/lsdserver/api/freshlicense_test.go
+++ b/lsdserver/api/freshlicense_test.go
@@ -1,0 +1,86 @@
+// Copyright 2021 Readium Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+
+package apilsd
+
+import (
+	"log"
+	"testing"
+
+	"github.com/readium/readium-lcp-server/config"
+)
+
+// enter here an existing license id
+var LicenseID string = "812bbfe8-9a57-4b14-b8f3-4e0fc6e841c0"
+
+func TestGetUserData(t *testing.T) {
+
+	// enter here a valid URL
+	config.Config.LsdServer.UserDataUrl = "http://xx.xx.xx.xx:pppp/aaaaa/{license_id}/aaaa"
+	// enter here valid credentials
+	config.Config.CMSAccessAuth.Username = "xxxxx"
+	config.Config.CMSAccessAuth.Password = "xxxxx"
+
+	log.Println("username ", config.Config.CMSAccessAuth.Username)
+
+	userData, err := getUserData(LicenseID)
+	if err != nil {
+		t.Error(err.Error())
+		t.FailNow()
+	}
+
+	if userData.Name == "" {
+		t.Error("Unexpected user name")
+	}
+}
+
+func TestInitPartialLicense(t *testing.T) {
+
+	userData := UserData{
+		ID:             "123-123-123",
+		Name:           "John Doe",
+		Email:          "jdoe@example.com",
+		Hint:           "Good hint",
+		PassphraseHash: "faeb00ca518bea7cb11a7ef31f63183b489b1b6eadb792bec64a03b3f6ff80a8",
+	}
+
+	plic, err := initPartialLicense(LicenseID, userData)
+
+	if err != nil {
+		t.Error(err.Error())
+		t.FailNow()
+	}
+	if plic.User.ID != userData.ID {
+		t.Error("Unexpected user ID")
+	}
+
+	if plic.Encryption.UserKey.Algorithm != Sha256_URL {
+		t.Error("Unexpected UserKey algorithm")
+	}
+}
+
+func TestFetchLicense(t *testing.T) {
+
+	// enter here a valid URL
+	config.Config.LcpServer.PublicBaseUrl = "http://xx.xx.xx.xx:pppp"
+	// enter here valid credentials
+	config.Config.LcpUpdateAuth.Username = "xxxx"
+	config.Config.LcpUpdateAuth.Password = "xxxx"
+
+	userData := UserData{
+		ID:             "123-123-123",
+		Name:           "John Doe",
+		Email:          "jdoe@example.com",
+		Hint:           "Good hint",
+		PassphraseHash: "faeb00ca518bea7cb11sdf434b6183b489b1b6eadb792bec64a03b3f6ff80a8",
+	}
+
+	plic, err := initPartialLicense(LicenseID, userData)
+
+	_, err = fetchLicense(plic)
+	if err != nil {
+		t.Error(err.Error())
+		t.FailNow()
+	}
+}

--- a/lsdserver/server/server.go
+++ b/lsdserver/server/server.go
@@ -9,12 +9,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/abbot/go-http-auth"
+	auth "github.com/abbot/go-http-auth"
 	"github.com/gorilla/mux"
 
 	"github.com/readium/readium-lcp-server/api"
-	"github.com/readium/readium-lcp-server/license_statuses"
-	"github.com/readium/readium-lcp-server/lsdserver/api"
+	licensestatuses "github.com/readium/readium-lcp-server/license_statuses"
+	apilsd "github.com/readium/readium-lcp-server/lsdserver/api"
 	"github.com/readium/readium-lcp-server/transactions"
 )
 
@@ -66,6 +66,7 @@ func New(bindAddr string, readonly bool, complianceMode bool, goofyMode bool, ls
 	s.handlePrivateFunc(sr.R, licenseRoutesPathPrefix, apilsd.FilterLicenseStatuses, basicAuth).Methods("GET")
 
 	s.handleFunc(licenseRoutes, "/{key}/status", apilsd.GetLicenseStatusDocument).Methods("GET")
+	s.handleFunc(licenseRoutes, "/{key}", apilsd.GetFreshLicense).Methods("GET")
 
 	if complianceMode {
 		s.handleFunc(sr.R, "/compliancetest", apilsd.AddLogToFile).Methods("POST")

--- a/pack/w3cpackage.go
+++ b/pack/w3cpackage.go
@@ -140,8 +140,9 @@ func generateRWPManifest(w3cman rwpm.W3CPublication) (manifest rwpm.Publication)
 
 	manifest.Context = []string{"https://readium.org/webpub-manifest/context.jsonld"}
 
-	if w3cman.ConformsTo == "https://www.w3/org/TR/audiobooks/" {
+	if w3cman.ConformsTo == "https://www.w3.org/TR/audiobooks/" {
 		manifest.Metadata.Type = "https://schema.org/Audiobook"
+		manifest.Metadata.ConformsTo = "https://readium.org/webpub-manifest/profiles/audiobook"
 	} else {
 		manifest.Metadata.Type = "https://schema.org/CreativeWork"
 	}

--- a/rwpm/metadata.go
+++ b/rwpm/metadata.go
@@ -13,6 +13,7 @@ import (
 // Metadata for the default context in WebPub
 type Metadata struct {
 	Type               string        `json:"@type,omitempty"`
+	ConformsTo         string        `json:"conformsTo,omitempty"`
 	Identifier         string        `json:"identifier,omitempty"`
 	Title              MultiLanguage `json:"title"`
 	Subtitle           MultiLanguage `json:"subtitle,omitempty"`

--- a/rwpm/w3cpublication.go
+++ b/rwpm/w3cpublication.go
@@ -10,6 +10,7 @@ import (
 
 // W3CPublication = W3C manifest
 type W3CPublication struct {
+	Type               string           `json:"type,omitempty"`
 	ConformsTo         string           `json:"conformsTo,omitempty"`
 	ID                 string           `json:"id,omitempty"`
 	URL                string           `json:"url,omitempty"`


### PR DESCRIPTION
This evolution allows the retrieval of a license (by its id) from the Status Doc Server. 

This development comes from the fact that many implementers don't manage to develop a proper [License Fetcher](https://github.com/readium/readium-lcp-server/wiki/Integrating-the-LCP-server-into-a-distribution-platform#fetch-an-existing-license) inside their CMS.  

The new route is (GET) &lt;LSDBaseURL>/licenses/<license_id>

All user information is fetched from the CMS via a specific REST method (which therefore must be implemented in the CMS). 

The user data payload is a json object with the following properties: 
- "id"
- "name"
- "email"
- "passphrasehash"
- "hint"

Access to the CMS is protected by basic auth. A new configuration section named `cms_access_auth` (with properties `username` and `password`) is created for this purpose, which must therefore be set in the Status Doc Server config. 
 
License information is retrieved from the License Server (as it would be from the CMS in the original setup). `lcp_update_auth` must therefore be set in the Status Doc Server config. 

The Frontend Test server is able to retrieve user data when called using the REST method above (using basic auth). 

NB: This PR also adds a few properties to the RWPM and W3C Manifest, solves minor issues with the default value of some struct in config.go, solve a json formatting issue with the "GetUsers" REST method of the Test Frontend server. 