### PR TITLE
Add base64 content key parameter in lcpencrypt

### DIFF
--- a/encrypt/process_encrypt.go
+++ b/encrypt/process_encrypt.go
@@ -28,7 +28,7 @@ import (
 
 // ProcessPublication encrypts a publication
 // inputPath must contain a processable file extension (EPUB, PDF, LPF or RPF)
-func ProcessPublication(contentID, inputPath, tempRepo, outputRepo, storageRepo, storageURL string) (*apilcp.LcpPublication, error) {
+func ProcessPublication(contentID, contentKey, inputPath, tempRepo, outputRepo, storageRepo, storageURL string) (*apilcp.LcpPublication, error) {
 
 	var pub apilcp.LcpPublication
 
@@ -95,13 +95,13 @@ func ProcessPublication(contentID, inputPath, tempRepo, outputRepo, storageRepo,
 
 	switch inputExt {
 	case ".epub":
-		err = processEPUB(&pub, inputPath, outputPath, encrypter)
+		err = processEPUB(&pub, inputPath, outputPath, encrypter, contentKey)
 	case ".pdf":
-		err = processPDF(&pub, inputPath, outputPath, encrypter)
+		err = processPDF(&pub, inputPath, outputPath, encrypter, contentKey)
 	case ".lpf":
-		err = processLPF(&pub, inputPath, outputPath, encrypter)
+		err = processLPF(&pub, inputPath, outputPath, encrypter, contentKey)
 	case ".audiobook", ".divina", ".webpub":
-		err = processRPF(&pub, inputPath, outputPath, encrypter)
+		err = processRPF(&pub, inputPath, outputPath, encrypter, contentKey)
 	}
 	if err != nil {
 		return nil, err
@@ -251,7 +251,7 @@ func checksum(file *os.File) string {
 }
 
 // processEPUB encrypts resources in an EPUB
-func processEPUB(pub *apilcp.LcpPublication, inputPath string, outputPath string, encrypter crypto.Encrypter) error {
+func processEPUB(pub *apilcp.LcpPublication, inputPath string, outputPath string, encrypter crypto.Encrypter, contentKey string) error {
 
 	// create a zip reader from the input path
 	zr, err := zip.OpenReader(inputPath)
@@ -274,7 +274,7 @@ func processEPUB(pub *apilcp.LcpPublication, inputPath string, outputPath string
 	defer outputFile.Close()
 	// encrypt the content of the publication,
 	// write  into the output file
-	_, encryptionKey, err := pack.Do(encrypter, epub, outputFile)
+	_, encryptionKey, err := pack.Do(encrypter, contentKey, epub, outputFile)
 	if err != nil {
 		return err
 	}
@@ -294,7 +294,7 @@ func processEPUB(pub *apilcp.LcpPublication, inputPath string, outputPath string
 }
 
 // processPDF wraps a PDF file inside a Readium Package and encrypts its resources
-func processPDF(pub *apilcp.LcpPublication, inputPath string, outputPath string, encrypter crypto.Encrypter) error {
+func processPDF(pub *apilcp.LcpPublication, inputPath string, outputPath string, encrypter crypto.Encrypter, contentKey string) error {
 
 	// generate a temp Readium Package (rwpp) which embeds the PDF file; its title is the PDF file name
 	tmpPackagePath := outputPath + ".tmp"
@@ -307,11 +307,11 @@ func processPDF(pub *apilcp.LcpPublication, inputPath string, outputPath string,
 	}
 
 	// build an encrypted package
-	return buildEncryptedRPF(pub, tmpPackagePath, outputPath, encrypter)
+	return buildEncryptedRPF(pub, tmpPackagePath, outputPath, encrypter, contentKey)
 }
 
 // processLPF transforms a W3C LPF file into a Readium Package and encrypts its resources
-func processLPF(pub *apilcp.LcpPublication, inputPath string, outputPath string, encrypter crypto.Encrypter) error {
+func processLPF(pub *apilcp.LcpPublication, inputPath string, outputPath string, encrypter crypto.Encrypter, contentKey string) error {
 
 	// generate a tmp Readium Package (rwpp) out of a W3C Package (lpf)
 	tmpPackagePath := outputPath + ".tmp"
@@ -324,19 +324,19 @@ func processLPF(pub *apilcp.LcpPublication, inputPath string, outputPath string,
 	}
 
 	// build an encrypted package
-	return buildEncryptedRPF(pub, tmpPackagePath, outputPath, encrypter)
+	return buildEncryptedRPF(pub, tmpPackagePath, outputPath, encrypter, contentKey)
 }
 
 // processRPF encrypts the source Readium Package
-func processRPF(pub *apilcp.LcpPublication, inputPath string, outputPath string, encrypter crypto.Encrypter) error {
+func processRPF(pub *apilcp.LcpPublication, inputPath string, outputPath string, encrypter crypto.Encrypter, contentKey string) error {
 
 	// build an encrypted package
-	return buildEncryptedRPF(pub, inputPath, outputPath, encrypter)
+	return buildEncryptedRPF(pub, inputPath, outputPath, encrypter, contentKey)
 }
 
 // buildEncryptedRPF builds an encrypted Readium package out of an un-encrypted one
 // FIXME: it cannot be used for EPUB as long as Do() and Process() are not merged
-func buildEncryptedRPF(pub *apilcp.LcpPublication, inputPath string, outputPath string, encrypter crypto.Encrypter) error {
+func buildEncryptedRPF(pub *apilcp.LcpPublication, inputPath string, outputPath string, encrypter crypto.Encrypter, contentKey string) error {
 
 	// create a reader on the un-encrypted readium package
 	reader, err := pack.OpenRPF(inputPath)
@@ -355,7 +355,7 @@ func buildEncryptedRPF(pub *apilcp.LcpPublication, inputPath string, outputPath 
 		return err
 	}
 	// encrypt resources from the input package, return the encryption key
-	encryptionKey, err := pack.Process(encrypter, reader, writer)
+	encryptionKey, err := pack.Process(encrypter, contentKey, reader, writer)
 	if err != nil {
 		return err
 	}

--- a/frontend/webpublication/webpublication.go
+++ b/frontend/webpublication/webpublication.go
@@ -137,7 +137,7 @@ func encryptPublication(inputPath string, pub Publication, pubManager Publicatio
 	// encrypt the publication
 	// FIXME: work on a direct storage of the output file.
 	outputRepo := pubManager.config.FrontendServer.EncryptedRepository
-	notification, err := encrypt.ProcessPublication("", inputPath, "", outputRepo, "", "")
+	notification, err := encrypt.ProcessPublication("", "", inputPath, "", outputRepo, "", "")
 	if err != nil {
 		return err
 	}

--- a/lcpencrypt/lcpencrypt.go
+++ b/lcpencrypt/lcpencrypt.go
@@ -24,6 +24,7 @@ func showHelpAndExit() {
 	fmt.Println("[-storage]    optional, final storage of the encrypted publication, fs or s3")
 	fmt.Println("[-url]        optional, base url associated with the storagen")
 	fmt.Println("[-contentid]  optional, content identifier; if omitted a uuid is generated")
+	fmt.Println("[-contentkey]  optional, base64 encoded content key; if omitted a random content key is generated")
 	fmt.Println("[-lcpsv]      optional, http endpoint, notification of the License server")
 	fmt.Println("[-login]      login (License server) ")
 	fmt.Println("[-password]   password (License server)")
@@ -45,6 +46,7 @@ func main() {
 	var storageRepo = flag.String("storage", "", "optional, final storage of the encrypted publication, fs or s3")
 	var storageURL = flag.String("url", "", "optional, base url associated with the storage")
 	var contentid = flag.String("contentid", "", "optional, content identifier; if omitted a uuid is generated")
+	var contentkey = flag.String("contentkey", "", "optional, base64 encoded content key; if omitted a random content key is generated")
 	var lcpsv = flag.String("lcpsv", "", "optional, http endpoint, notification of the License server")
 	var username = flag.String("login", "", "login (License server)")
 	var password = flag.String("password", "", "password (License server)")
@@ -66,7 +68,7 @@ func main() {
 	}
 
 	// encrypt the publication
-	pub, err := encrypt.ProcessPublication(*contentid, *inputPath, *tempRepo, *outputRepo, *storageRepo, *storageURL)
+	pub, err := encrypt.ProcessPublication(*contentid, *contentkey, *inputPath, *tempRepo, *outputRepo, *storageRepo, *storageURL)
 	if err != nil {
 		exitWithError("Process a publication", err)
 	}

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/url"
 	"strings"
+	"encoding/base64"
 
 	"github.com/readium/readium-lcp-server/crypto"
 	"github.com/readium/readium-lcp-server/epub"
@@ -42,16 +43,30 @@ type Resource interface {
 	Open() (io.ReadCloser, error)
 }
 
-// Process copies resources from the source to the destination package, after encryption if needed.
-func Process(encrypter crypto.Encrypter, reader PackageReader, writer PackageWriter) (key crypto.ContentKey, err error) {
+func GetOrSetContentKey(encrypter crypto.Encrypter, contentKey string)  (key crypto.ContentKey, err error) {
+	if contentKey != "" {
+		key,err = base64.StdEncoding.DecodeString(contentKey)
+		if err != nil {
+			log.Println("Error unpacking given content key")
+			return nil,err
+		}
+	} else {
+		key, err = encrypter.GenerateKey()
+		if err != nil {
+			log.Println("Error generating an encryption key")
+			return nil,err
+		}
+	}
+	return key,nil
+}
 
-	// generate an encryption key
-	key, err = encrypter.GenerateKey()
-	if err != nil {
-		log.Println("Error generating an encryption key")
+
+// Process copies resources from the source to the destination package, after encryption if needed.
+func Process(encrypter crypto.Encrypter, contentKey string, reader PackageReader, writer PackageWriter) (key crypto.ContentKey, err error) {
+
+	if key,err = GetOrSetContentKey(encrypter, contentKey); err != nil {
 		return
 	}
-
 	// create a compressing tool
 	var buf bytes.Buffer
 	compressor, err := flate.NewWriter(&buf, flate.BestCompression)
@@ -70,6 +85,7 @@ func Process(encrypter crypto.Encrypter, reader PackageReader, writer PackageWri
 		} else {
 			err = resource.CopyTo(writer)
 			if err != nil {
+				log.Println("Error copying the file")
 				return
 			}
 		}
@@ -86,12 +102,10 @@ func Process(encrypter crypto.Encrypter, reader PackageReader, writer PackageWri
 // Do encrypts when necessary the resources of an EPUB package
 // It is called for EPUB files only
 // FIXME: try to merge Process() and Do()
-func Do(encrypter crypto.Encrypter, ep epub.Epub, w io.Writer) (enc *xmlenc.Manifest, key crypto.ContentKey, err error) {
+func Do(encrypter crypto.Encrypter, contentKey string, ep epub.Epub, w io.Writer) (enc *xmlenc.Manifest, key crypto.ContentKey, err error) {
 
 	// generate an encryption key
-	key, err = encrypter.GenerateKey()
-	if err != nil {
-		log.Println("Error generating a key")
+	if key,err = GetOrSetContentKey(encrypter, contentKey); err != nil {
 		return
 	}
 

--- a/pack/pipeline.go
+++ b/pack/pipeline.go
@@ -147,7 +147,7 @@ func (p Packager) encrypt(r *Result, ep epub.Epub) (*EncryptedFileInfo, []byte) 
 		return nil, nil
 	}
 	encrypter := crypto.NewAESEncrypter_PUBLICATION_RESOURCES()
-	_, key, err := Do(encrypter, ep, tmpFile)
+	_, key, err := Do(encrypter, "", ep, tmpFile)
 	r.Error = err
 	var encryptedFileInfo EncryptedFileInfo
 	encryptedFileInfo.File = tmpFile


### PR DESCRIPTION
The goal is to use the content key (base64 encoded) as a parameter for
lcpencrypt in order to manage content update (with the same content key)
without re-creating a license for the user.