### PR TITLE
Fix contents delete for postgres driver

### DIFF
--- a/index/index.go
+++ b/index/index.go
@@ -87,8 +87,15 @@ func (i dbIndex) Update(c Content) error {
 
 // Delete deletes a record
 func (i dbIndex) Delete(id string) error {
-	_, err := i.db.Exec("DELETE FROM content WHERE id=?", id)
-	return err
+	driver, _ := config.GetDatabase(config.Config.LcpServer.Database)
+
+	if driver == "postgres" {
+		_, err := i.db.Exec(dbutils.GetParamQuery(config.Config.LcpServer.Database, "DELETE FROM content WHERE id=?"), id)
+		return err
+	} else {
+		_, err := i.db.Exec("DELETE FROM content WHERE id=?", id)
+		return err
+	}
 }
 
 // List lists rows


### PR DESCRIPTION
this fixes calling DELETE contents using the postgres driver resulting in:

```
❯ curl -s -X DELETE -u "user:pass" localhost/contents/1 | jq
{
  "type": "http://readium.org/license-status-document/error/server",
  "title": "Internal Server Error",
  "status": 500,
  "detail": "Index:pq: syntax error at end of input",
  "instance": "1"
}
```