### PR TITLE
Add get content info from licence id

### DIFF
--- a/lcpserver/server/server.go
+++ b/lcpserver/server/server.go
@@ -154,6 +154,8 @@ func New(bindAddr string, readonly bool, idx *index.Index, st *storage.Store, ls
 	// get a license
 	s.handlePrivateFunc(licenseRoutes, "/{license_id}", apilcp.GetLicense, basicAuth).Methods("GET")
 	s.handlePrivateFunc(licenseRoutes, "/{license_id}", apilcp.GetLicense, basicAuth).Methods("POST")
+	// get content via licence id
+	s.handlePrivateFunc(licenseRoutes, "/{license_id}/content", apilcp.GetContentInfoFromLicense, basicAuth).Methods("GET")
 	// get a protected publication via a license id
 	s.handlePrivateFunc(licenseRoutes, "/{license_id}/publication", apilcp.GetProtectedPublication, basicAuth).Methods("POST")
 	if !readonly {


### PR DESCRIPTION
Add a way to given the license id lookup content info.
We already have all of the information we need available in the lcpserver database.

this mr put the endpoint at `licenses/{license_id}/content` which then returns the `index.Content` domain object.
From the outside this looks like:

```
curl "<lcpserver base url>/licenses/<license id>/content" | jq
{
  "id": "<some content id>",
  "key": "<some content key>",
  "location": "<some content location>",
  "length": <some content length>,
  "sha256": "<some content sha>",
  "type": "<some content type>"
}
```