### PR TITLE
Fix Page map encryption.

### DIFF
--- a/epub/epub.go
+++ b/epub/epub.go
@@ -23,7 +23,8 @@ const (
 	ContentType_XHTML = "application/xhtml+xml"
 	ContentType_HTML  = "text/html"
 
-	ContentType_NCX = "application/x-dtbncx+xml"
+	ContentType_NCX     = "application/x-dtbncx+xml"
+	ContentType_PAGEMAP = "application/oebps-page-map+xml"
 
 	ContentType_EPUB = "application/epub+zip"
 )

--- a/epub/reader.go
+++ b/epub/reader.go
@@ -179,7 +179,8 @@ func addCleartextResources(ep *Epub, p opf.Package) {
 		if strings.Contains(item.Properties, "cover-image") ||
 			item.ID == coverImageID ||
 			strings.Contains(item.Properties, "nav") ||
-			item.MediaType == ContentType_NCX {
+			item.MediaType == ContentType_NCX ||
+			item.MediaType == ContentType_PAGEMAP {
 			// re-construct a path, avoid insertion of backslashes as separator on Windows
 			path := filepath.ToSlash(filepath.Join(p.BasePath, item.Href))
 			ep.addCleartextResource(path)


### PR DESCRIPTION
About page-map.xml: https://groups.google.com/g/epubcheck/c/bSmUs1OP9oc

An EPUB2 page map must not be encrypted. 
Its syntax is &lt;item id="pages" href="pages.xml" media-type="application/oebps-page-map+xml"/>