### PR TITLE
Merge master to cd_dev

### DIFF
--- a/lcpserver/lcpserver.go
+++ b/lcpserver/lcpserver.go
@@ -103,15 +103,15 @@ func main() {
 		}
 	}
 
-	idx, err := index.Open(db)
-	if err != nil {
-		log.Println("Error opening the index db: " + err.Error())
-		os.Exit(1)
-	}
-
 	lst, err := license.Open(db)
 	if err != nil {
 		log.Println("Error opening the license db: " + err.Error())
+		os.Exit(1)
+	}
+
+	idx, err := index.Open(db)
+	if err != nil {
+		log.Println("Error opening the index db: " + err.Error())
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Cause: we can now get content by license, the preparation of this request imposes the license table to be created.