### PR TITLE
Support S3-compatible providers via CLI flags in lcpencrypt

### DIFF
--- a/encrypt/process_encrypt.go
+++ b/encrypt/process_encrypt.go
@@ -51,7 +51,7 @@ type Publication struct {
 
 // ProcessEncryption encrypts a publication
 // inputPath must contain a processable file extension.
-func ProcessEncryption(contentID, contentKey, inputPath, tempRepo, outputRepo, storageRepo, storageURL, storageFilename string, extractCover, pdfNoMeta bool) (*Publication, error) {
+func ProcessEncryption(contentID, contentKey, inputPath, tempRepo, outputRepo, storageRepo, storageURL, storageFilename string, extractCover, pdfNoMeta bool, s3opts S3Options) (*Publication, error) {
 
 	if inputPath == "" {
 		return nil, errors.New("ProcessEncryption, missing input path")
@@ -183,7 +183,7 @@ func ProcessEncryption(contentID, contentKey, inputPath, tempRepo, outputRepo, s
 		// the encryption tool stores the encrypted publication in an S3 storage
 		// and delete the temp file
 		fromPath := filepath.Join(pub.OutputRepo, pub.FileName)
-		err = StoreFileOnS3(fromPath, storageRepo, pub.FileName)
+		err = StoreFileOnS3(fromPath, storageRepo, pub.FileName, s3opts)
 		if err != nil {
 			return nil, err
 		}
@@ -191,7 +191,7 @@ func ProcessEncryption(contentID, contentKey, inputPath, tempRepo, outputRepo, s
 		// and delete the cover
 		if pub.ExtractCover && pub.CoverName != "" {
 			fromPath := filepath.Join(pub.OutputRepo, pub.CoverName)
-			err = StoreFileOnS3(fromPath, storageRepo, pub.CoverName)
+			err = StoreFileOnS3(fromPath, storageRepo, pub.CoverName, s3opts)
 			if err != nil {
 				return nil, err
 			}

--- a/encrypt/store_publication.go
+++ b/encrypt/store_publication.go
@@ -12,15 +12,24 @@ import (
 	"github.com/readium/readium-lcp-server/storage"
 )
 
+type S3Options struct {
+	Endpoint       string
+	ForcePathStyle bool
+	DisableSSL     bool
+}
+
 // StoreFileOnS3 stores an encrypted file or cover image into its definitive storage.
 // it then deletes the input file.
-func StoreFileOnS3(inputPath, storageRepo, name string) error {
+func StoreFileOnS3(inputPath, storageRepo, name string, opts S3Options) error {
 
 	s3Split := strings.Split(storageRepo, ":")
 
 	s3conf := storage.S3Config{}
 	s3conf.Region = s3Split[1]
 	s3conf.Bucket = s3Split[2]
+	s3conf.Endpoint = opts.Endpoint
+	s3conf.ForcePathStyle = opts.ForcePathStyle
+	s3conf.DisableSSL = opts.DisableSSL
 
 	var store storage.Store
 	// init the S3 storage

--- a/frontend/webpublication/webpublication.go
+++ b/frontend/webpublication/webpublication.go
@@ -108,7 +108,7 @@ func encryptPublication(inputPath string, pub *Publication, pubManager Publicati
 	// FIXME: work on a direct storage of the output file.
 	outputRepo := config.Config.FrontendServer.EncryptedRepository
 	empty := ""
-	notification, err := encrypt.ProcessEncryption(empty, empty, inputPath, empty, outputRepo, empty, empty, empty, false, false)
+	notification, err := encrypt.ProcessEncryption(empty, empty, inputPath, empty, outputRepo, empty, empty, empty, false, false, encrypt.S3Options{})
 	if err != nil {
 		return err
 	}

--- a/lcpencrypt/lcpencrypt.go
+++ b/lcpencrypt/lcpencrypt.go
@@ -31,6 +31,9 @@ func showHelpAndExit() {
 	fmt.Println("-provider   publication provider (URI)")
 	fmt.Println("-storage    optional, target location of the encrypted publication, without filename. File system path or s3 bucket")
 	fmt.Println("-url        optional, base url associated with the storage, without filename")
+	fmt.Println("-s3-endpoint           optional, custom S3 endpoint URL for S3-compatible providers (e.g. Cloudflare R2, MinIO)")
+	fmt.Println("-s3-force-path-style   optional, boolean, use path-style S3 URLs; required by some S3-compatible providers")
+	fmt.Println("-s3-disable-ssl        optional, boolean, disable SSL when talking to the S3 endpoint")
 	fmt.Println("-filename   optional, file name for the encrypted publication; if omitted, contentid is used")
 	fmt.Println("-temp       optional, working folder for temporary files. If not set, the current directory will be used.")
 	fmt.Println("-cover      optional, boolean, indicates that a cover should be generated")
@@ -75,6 +78,9 @@ func main() {
 	password := flag.String("password", "", "optional unless lcpsv is used, password for the License server")
 	notify := flag.String("notify", "", "URL, notification endpoint for a CMS; its syntax is http://username:password@example.com")
 	verbose := flag.Bool("verbose", false, "boolean, the information sent to the LCP Server and CMS will be displayed")
+	s3Endpoint := flag.String("s3-endpoint", "", "optional, custom S3 endpoint for S3-compatible storage providers (e.g. Cloudflare R2, MinIO, Backblaze B2)")
+	s3ForcePathStyle := flag.Bool("s3-force-path-style", false, "optional, use path-style S3 URLs (bucket in path instead of subdomain); often required by S3-compatible providers")
+	s3DisableSSL := flag.Bool("s3-disable-ssl", false, "optional, disable SSL when talking to the S3 endpoint; intended for local/dev S3-compatible servers")
 
 	help := flag.Bool("help", false, "shows information")
 
@@ -126,7 +132,12 @@ func main() {
 	}
 
 	// encrypt the publication
-	publication, err := encrypt.ProcessEncryption(*contentid, *contentkey, *inputPath, *tempRepo, *outputRepo, *storageRepo, *storageURL, *storageFilename, *cover, *pdfnometa)
+	s3opts := encrypt.S3Options{
+		Endpoint:       *s3Endpoint,
+		ForcePathStyle: *s3ForcePathStyle,
+		DisableSSL:     *s3DisableSSL,
+	}
+	publication, err := encrypt.ProcessEncryption(*contentid, *contentkey, *inputPath, *tempRepo, *outputRepo, *storageRepo, *storageURL, *storageFilename, *cover, *pdfnometa, s3opts)
 	if err != nil {
 		exitWithError("Error processing a publication", err)
 	}


### PR DESCRIPTION
The S3 storage backend already accepts Endpoint, ForcePathStyle and DisableSSL on its config struct, but these were never wired up to the CLI — so lcpencrypt could only target real AWS, not Cloudflare R2, MinIO, Backblaze B2, or any other S3-compatible service.

Adds three optional flags on lcpencrypt:
  -s3-endpoint
  -s3-force-path-style
  -s3-disable-ssl